### PR TITLE
Speedup matrix ops

### DIFF
--- a/rustynum-rs/src/num_array/num_array.rs
+++ b/rustynum-rs/src/num_array/num_array.rs
@@ -195,6 +195,29 @@ where
         }
     }
 
+    /// Transposes a 2D matrix from row-major to column-major format.
+    ///
+    /// # Returns
+    /// A new `NumArray` instance that is the transpose of the original matrix.
+    pub fn transpose(&self) -> Self {
+        assert!(
+            self.shape.len() == 2,
+            "Transpose is only valid for 2D matrices."
+        );
+
+        let rows = self.shape[0];
+        let cols = self.shape[1];
+        let mut transposed_data = vec![T::default(); rows * cols];
+
+        for i in 0..rows {
+            for j in 0..cols {
+                transposed_data[j * rows + i] = self.data[i * cols + j];
+            }
+        }
+
+        NumArray::new_with_shape(transposed_data, vec![cols, rows])
+    }
+
     /// Retrieves a reference to the underlying data vector.
     ///
     /// # Returns
@@ -617,9 +640,10 @@ where
     /// println!("Row slice: {:?}", row_slice);
     /// ```
     pub fn row_slice(&self, row: usize) -> &[T] {
-        assert_eq!(self.shape().len(), 2, "Only 2D arrays are supported.");
-        let start = row * self.shape()[1];
-        let end = start + self.shape()[1];
+        let shape = self.shape();
+        assert_eq!(shape.len(), 2, "Only 2D arrays are supported.");
+        let start = row * shape[1];
+        let end = start + shape[1];
         &self.data[start..end]
     }
 
@@ -827,6 +851,34 @@ mod tests {
         let ones_array = NumArray32::ones(shape.clone());
         assert_eq!(ones_array.shape(), shape.as_slice());
         assert_eq!(ones_array.get_data(), &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn test_matrix_transpose() {
+        let matrix = NumArray32::new_with_shape(
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+            vec![3, 3],
+        );
+
+        let transposed = matrix.transpose();
+
+        let expected_data = vec![1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0];
+
+        assert_eq!(transposed.shape(), &[3, 3]);
+        assert_eq!(transposed.get_data(), &expected_data);
+    }
+
+    #[test]
+    fn test_non_square_matrix_transpose() {
+        let matrix =
+            NumArray32::new_with_shape(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], vec![2, 4]);
+
+        let transposed = matrix.transpose();
+
+        let expected_data = vec![1.0, 5.0, 2.0, 6.0, 3.0, 7.0, 4.0, 8.0];
+
+        assert_eq!(transposed.shape(), &[4, 2]);
+        assert_eq!(transposed.get_data(), &expected_data);
     }
 
     #[test]

--- a/rustynum-rs/src/simd_ops/mod.rs
+++ b/rustynum-rs/src/simd_ops/mod.rs
@@ -1,6 +1,7 @@
 use std::simd::f32x16;
 use std::simd::f64x8;
 use std::simd::num::SimdFloat;
+use std::simd::StdFloat;
 
 const LANES_32: usize = 16;
 const LANES_64: usize = 8;
@@ -16,13 +17,13 @@ impl SimdOps<f32> for f32x16 {
     fn dot_product(a: &[f32], b: &[f32]) -> f32 {
         assert_eq!(a.len(), b.len());
         let len = a.len();
-        let mut sum = f32x16::splat(0.0);
+        let sum = f32x16::splat(0.0);
 
         let chunks = len / LANES_32;
         for i in 0..chunks {
             let a_simd = f32x16::from_slice(&a[i * LANES_32..]);
             let b_simd = f32x16::from_slice(&b[i * LANES_32..]);
-            sum += a_simd * b_simd;
+            let _ = sum.mul_add(a_simd, b_simd);
         }
 
         let mut scalar_sum = sum.reduce_sum();
@@ -87,25 +88,22 @@ impl SimdOps<f32> for f32x16 {
 impl SimdOps<f64> for f64x8 {
     fn dot_product(a: &[f64], b: &[f64]) -> f64 {
         assert_eq!(a.len(), b.len());
+        let len = a.len();
+        let sum = f64x8::splat(0.0);
 
-        let (a_extra, a_chunks) = a.as_rchunks();
-        let (b_extra, b_chunks) = b.as_rchunks();
-
-        // These are always true, but for emphasis:
-        assert_eq!(a_chunks.len(), b_chunks.len());
-        assert_eq!(a_extra.len(), b_extra.len());
-
-        let mut sums = [0.0; LANES_64];
-        for ((x, y), d) in std::iter::zip(a_extra, b_extra).zip(&mut sums) {
-            *d = x * y;
+        let chunks = len / LANES_64;
+        for i in 0..chunks {
+            let a_simd = f64x8::from_slice(&a[i * LANES_64..]);
+            let b_simd = f64x8::from_slice(&b[i * LANES_64..]);
+            let _ = sum.mul_add(a_simd, b_simd);
         }
 
-        let mut sums = f64x8::from_array(sums);
-        std::iter::zip(a_chunks, b_chunks).for_each(|(x, y)| {
-            sums += f64x8::from_array(*x) * f64x8::from_array(*y);
-        });
+        let mut scalar_sum = sum.reduce_sum();
+        for i in (chunks * LANES_64)..len {
+            scalar_sum += a[i] * b[i];
+        }
 
-        sums.reduce_sum()
+        scalar_sum
     }
 
     fn sum(a: &[f64]) -> f64 {


### PR DESCRIPTION
This PR brings speed improvements for the dot product implementation. The previous code did not use FMA operations as supported by modern CPUs. FMA operations allow for multiplication and addition in a single clock cycle on modern CPUs effectively doubling throughput.

Old code:
```rust
sum += a_simd * b_simd;
```

New code:
```rust
let _ = sum.mul_add(a_simd, b_simd);
```

With some other minor improvements the new code uses
- `55.32%` less time for matrix vector multiplications
- `56.72%` less time for matrix matrix multiplications

Rustynums performance is now getting more close to ndarray and nalgebra without relying on multithreading or third party dependencies. 


Benchmarked with
```bash
cd rustynum-rs/ && cargo criterion
```
on Apple Silicon M1 Pro.

Matrix 1000 x 1000
Vector 1000

## Before this PR

### Matrix Vector multiplications
<img width="975" alt="image" src="https://github.com/user-attachments/assets/f6b4fde8-a27d-47c6-a7df-f0d42da64299">
<img width="649" alt="image" src="https://github.com/user-attachments/assets/739a14bc-4a55-4c46-b1e2-24915349016c">

### Matrix Matrix multiplications
<img width="980" alt="image" src="https://github.com/user-attachments/assets/607914dd-3c5e-4b26-9992-d4a4b301090f">
<img width="637" alt="image" src="https://github.com/user-attachments/assets/a349d0df-814c-4817-824e-283416dc27cb">


## After this PR

### Matrix Vector multiplications
<img width="978" alt="image" src="https://github.com/user-attachments/assets/c4ede1f1-a51b-49cd-87a0-ff10644ca09b">
<img width="635" alt="image" src="https://github.com/user-attachments/assets/bd4f5ee9-cf75-44da-8ea6-bcfd018d3f34">


### Matrix Matrix multiplications
<img width="971" alt="image" src="https://github.com/user-attachments/assets/fa06d28b-31b5-4f1b-a83d-914559b2ca72">
<img width="631" alt="image" src="https://github.com/user-attachments/assets/86ac4eb4-c8d7-41f3-a963-33f951756482">
