### PR TITLE
Add experimental integer (uint8) support and flipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ RustyNum offers a variety of numerical operations and data types, with more feat
 
 - float64
 - float32
+- uint8 (experimental)
 - int32 (Planned)
 - int64 (Planned)
 
@@ -105,6 +106,8 @@ RustyNum offers a variety of numerical operations and data types, with more feat
 | Element-wise Sub | `a - b`                         | `a - b`                          |
 | Element-wise Mul | `a * b`                         | `a * b`                          |
 | Element-wise Div | `a / b`                         | `a / b`                          |
+| Fancy indexing   | `np.ones((2,3))[0, :]`          | `rnp.ones((2,3))[0, :]`          |
+| Fancy flipping   | `np.array([1,2,3])[::-1]`       | `rnp.array([1,2,3])[::-1]`       |
 
 ### NumArray Class
 
@@ -269,7 +272,7 @@ In addition to the Python bindings, RustyNum’s core library is implemented in 
 #### Observations
 
 - RustyNum is able to perform on par with nalgebra and ndarray in most operations and sometimes even outperforms them.
-- There seems a significant overhead in the Python bindings. We're getting 10ms in RustyNum for the matrix-vector multiplication with 1k elements vs 77us.
+- There seems a significant overhead in the Python bindings. We're getting 10ms in Python in RustyNum for the matrix-vector multiplication with 1k elements vs 77us in Rust.
 
 # Build
 

--- a/bindings/python/rustynum/__init__.py
+++ b/bindings/python/rustynum/__init__.py
@@ -43,7 +43,7 @@ class NumArray:
                 flat_data = self._flatten(data)
 
                 if dtype is None:
-                    dtype = self._infer_dtype_from_data(data)
+                    dtype = self._infer_dtype_from_data(flat_data)
                 self.dtype = dtype
 
                 if dtype == "float32":
@@ -61,8 +61,10 @@ class NumArray:
                     raise ValueError(f"Unsupported dtype: {dtype}")
             else:
                 # Handling for non-nested lists (1D arrays)
-                flat_data = self._flatten(data)
-                shape = [len(flat_data)]
+                if isinstance(data, list):
+                    flat_data = data
+                else:
+                    flat_data = [data]
 
                 if dtype is None:
                     dtype = self._infer_dtype_from_data(flat_data)
@@ -144,12 +146,16 @@ class NumArray:
         Returns:
             A string representing the dtype.
         """
-        if all(isinstance(x, int) for x in data):
-            return "int32" if all(x < 2**31 for x in data) else "int64"
-        elif all(isinstance(x, float) for x in data):
+        first_type = type(data[0])
+        if first_type is int:
+            max_val = max(data[0])
+            return "int32" if max_val < 2**31 else "int64"
+        elif first_type is float:
             return "float32"  # Default to float32
+        elif first_type is bytes or first_type is bytearray:
+            return "uint8"
         else:
-            raise ValueError("Mixed or unsupported data types in data.")
+            raise ValueError("Unsupported data type in data.")
 
     @property
     def shape(self) -> List[int]:

--- a/bindings/python/rustynum/__init__.py
+++ b/bindings/python/rustynum/__init__.py
@@ -1,7 +1,8 @@
 # rustynum_py_wrapper/__init__.py
 from . import _rustynum
-from typing import Any, List, Sequence, Union
+from typing import Any, List, Sequence, Tuple, Union
 import itertools
+import math
 
 
 class NumArray:
@@ -21,37 +22,63 @@ class NumArray:
         if isinstance(data, NumArray):
             self.inner = data.inner
             self.dtype = data.dtype
-        elif isinstance(data, (_rustynum.PyNumArray32, _rustynum.PyNumArray64)):
+        elif isinstance(
+            data,
+            (_rustynum.PyNumArrayF32, _rustynum.PyNumArrayF64, _rustynum.PyNumArrayU8),
+        ):
             self.inner = data
-            self.dtype = (
-                "float32" if isinstance(data, _rustynum.PyNumArray32) else "float64"
-            )
+            if isinstance(data, _rustynum.PyNumArrayF32):
+                self.dtype = "float32"
+            elif isinstance(data, _rustynum.PyNumArrayF64):
+                self.dtype = "float64"
+            elif isinstance(data, _rustynum.PyNumArrayU8):
+                self.dtype = "uint8"
+            else:
+                self.dtype = "unknown"
         else:
             # Determine if data is nested (e.g., list of lists)
-            if not self._is_nested_list(data):
+            if self._is_nested_list(data):
+                # Handling for nested lists
+                shape = self._infer_shape(data)
+                flat_data = self._flatten(data)
+
                 if dtype is None:
                     dtype = self._infer_dtype_from_data(data)
                 self.dtype = dtype
 
                 if dtype == "float32":
-                    self.inner = _rustynum.PyNumArray32(data)
+                    self.inner = _rustynum.PyNumArrayF32(flat_data, shape)
                 elif dtype == "float64":
-                    self.inner = _rustynum.PyNumArray64(data)
+                    self.inner = _rustynum.PyNumArrayF64(flat_data, shape)
+                elif dtype == "uint8":
+                    self.inner = _rustynum.PyNumArrayU8(flat_data, shape)
+                elif dtype in ("int32", "int64"):
+                    # Implement PyNumArrayInt32 and PyNumArrayInt64 similarly if needed
+                    raise NotImplementedError(
+                        f"dtype '{dtype}' is not yet implemented."
+                    )
                 else:
                     raise ValueError(f"Unsupported dtype: {dtype}")
             else:
-                # Handling for nested lists
-                shape = self._infer_shape(data)
+                # Handling for non-nested lists (1D arrays)
                 flat_data = self._flatten(data)
+                shape = [len(flat_data)]
 
                 if dtype is None:
                     dtype = self._infer_dtype_from_data(flat_data)
                 self.dtype = dtype
 
                 if dtype == "float32":
-                    self.inner = _rustynum.PyNumArray32(flat_data, shape)
+                    self.inner = _rustynum.PyNumArrayF32(flat_data)
                 elif dtype == "float64":
-                    self.inner = _rustynum.PyNumArray64(flat_data, shape)
+                    self.inner = _rustynum.PyNumArrayF64(flat_data)
+                elif dtype == "uint8":
+                    self.inner = _rustynum.PyNumArrayU8(flat_data)
+                elif dtype in ("int32", "int64"):
+                    # Implement PyNumArrayInt32 and PyNumArrayInt64 similarly if needed
+                    raise NotImplementedError(
+                        f"dtype '{dtype}' is not yet implemented."
+                    )
                 else:
                     raise ValueError(f"Unsupported dtype: {dtype}")
 
@@ -133,22 +160,60 @@ class NumArray:
         # You may need to implement this method in Rust if it doesn't exist
         return self.inner.shape()
 
-    def __getitem__(self, key: Union[int, slice]) -> Union[List[float], "NumArray"]:
+    def __getitem__(
+        self, key: Union[int, slice, Tuple[Any]]
+    ) -> Union[List[Any], "NumArray"]:
         """
         Gets the item(s) at the specified index or slice.
 
+        Supports single-axis flipping using slice with step=-1.
+
         Parameters:
-            key: Index or slice for the item(s) to get.
+            key: Index, slice, or tuple of indices/slices for access.
 
         Returns:
             Single item or a new NumArray with the sliced data.
         """
-        if isinstance(key, slice):
-            start, stop, _ = key.indices(len(self.tolist()))
-            sliced_data = self.inner.slice(start, stop).tolist()
-            return NumArray(sliced_data, dtype=self.dtype)
-        else:
-            return self.tolist()[key]
+        # Normalize the key to a tuple for uniform processing
+        if not isinstance(key, tuple):
+            key = (key,)
+
+        # Ensure the number of indices does not exceed the number of dimensions
+        if len(key) > len(self.shape):
+            raise IndexError("Too many indices for NumArray")
+
+        # Start with the current NumArray
+        result = self
+
+        # Iterate over each dimension and corresponding key
+        for axis, k in enumerate(key):
+            if isinstance(k, slice):
+                # Check if the slice has a step of -1 (indicating a flip)
+                if k.step == -1:
+                    # Flip the specified axis
+                    result = result.flip(axis)
+                elif k.step is None or k.step == 1:
+                    # Perform standard slicing
+                    result = result.slice(axis, k.start, k.stop)
+                else:
+                    # For simplicity, only handle step=None, step=1, or step=-1
+                    raise NotImplementedError(
+                        "Only full slices or slice with step=-1 are supported."
+                    )
+            elif isinstance(k, int):
+                # Handle integer indexing as before
+                if k < 0:
+                    k += result.shape[axis]
+                if not (0 <= k < result.shape[axis]):
+                    raise IndexError(
+                        f"Index {k} out of bounds for axis {axis} with size {result.shape[axis]}"
+                    )
+                # Perform the integer indexing by slicing the data
+                result = NumArray(result.inner.slice(axis, k, k + 1), dtype=self.dtype)
+            else:
+                raise TypeError(f"Unsupported index type: {type(k)}")
+
+        return result
 
     def __str__(self) -> str:
         return str(self.tolist())
@@ -396,16 +461,23 @@ class NumArray:
                 )
             )
 
-    def tolist(self) -> Union[List[float], List[List[float]]]:
+    def tolist(self) -> List[Any]:
         flat_list = self.inner.tolist()
         shape = self.shape
-        if len(shape) == 1:
-            return flat_list  # Already a 1D list, no changes needed
-        elif len(shape) == 2:
-            # Reshape flat list into a list of lists (2D)
-            return [
-                flat_list[i * shape[1] : (i + 1) * shape[1]] for i in range(shape[0])
-            ]
+
+        def build_nested(flat, shape):
+            if not shape:
+                raise ValueError("Shape cannot be empty")
+            if len(shape) == 1:
+                return flat[: shape[0]]
+            else:
+                step = math.prod(shape[1:])  # Number of elements in each sublist
+                return [
+                    build_nested(flat[i * step : (i + 1) * step], shape[1:])
+                    for i in range(shape[0])
+                ]
+
+        return build_nested(flat_list, shape)
 
     def exp(self) -> "NumArray":
         """
@@ -457,6 +529,52 @@ class NumArray:
         else:
             raise ValueError("Unsupported dtype for concatenation")
 
+        return NumArray(result, dtype=self.dtype)
+
+    def flip(self, axis: Union[int, Sequence[int]]) -> "NumArray":
+        """
+        Flips the NumArray along the specified axes.
+
+        Parameters:
+            axis: Axis to flip along.
+
+        Returns:
+            A new NumArray with the flipped data.
+        """
+        if isinstance(axis, int):
+            result = self.inner.flip_axes([axis])
+        elif isinstance(axis, (list, tuple)):
+            result = self.inner.flip_axes(list(axis))
+        else:
+            raise TypeError("axis must be an integer or a sequence of integers")
+        return NumArray(result, dtype=self.dtype)
+
+    def slice(
+        self, axis: int, start: Union[int, None], stop: Union[int, None]
+    ) -> "NumArray":
+        """
+        Slices the NumArray along a specified axis.
+
+        Parameters:
+            axis: Axis to slice.
+            start: Starting index of the slice.
+            stop: Stopping index of the slice.
+
+        Returns:
+            A new NumArray with the sliced data.
+        """
+        # Handle None values by setting defaults
+        if start is None:
+            start = 0
+        elif start < 0:
+            start += self.shape[axis]
+
+        if stop is None:
+            stop = self.shape[axis]
+        elif stop < 0:
+            stop += self.shape[axis]
+
+        result = self.inner.slice(axis, start, stop)
         return NumArray(result, dtype=self.dtype)
 
 

--- a/bindings/python/tests/test_basics.py
+++ b/bindings/python/tests/test_basics.py
@@ -2,6 +2,57 @@ import numpy as np
 import rustynum as rnp
 
 
+def test_flat_explicit_dtype_f32():
+    a = rnp.NumArray([1.0, 2.0, 3.0], dtype="float32")
+    b = np.array([1.0, 2.0, 3.0], dtype="float32")
+    assert np.allclose(a.tolist(), b, atol=1e-9), "Flat array creation failed"
+
+
+def test_flat_explicit_dtype_u8():
+    a = rnp.NumArray([1, 2, 3], dtype="uint8")
+    b = np.array([1, 2, 3], dtype="uint8")
+    assert np.allclose(a.tolist(), b, atol=1e-9), "Flat array creation failed"
+
+
+def test_nested_explicit_dtype_f32():
+    a = rnp.NumArray([[1.0, 2.0], [3.0, 4.0]], dtype="float32")
+    b = np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32")
+    assert np.allclose(a.tolist(), b, atol=1e-9), "Nested array creation failed"
+
+
+def test_nested_explicit_dtype_u8():
+    a = rnp.NumArray([[1, 2], [3, 4]], dtype="uint8")
+    b = np.array([[1, 2], [3, 4]], dtype="uint8")
+    assert np.allclose(a.tolist(), b, atol=1e-9), "Nested array creation failed"
+
+
+def test_flat_inferred_dtype_f32():
+    a = rnp.NumArray([1.0, 2.0, 3.0])
+    b = np.array([1.0, 2.0, 3.0], dtype="float32")
+    assert np.allclose(a.tolist(), b, atol=1e-9), "Flat array creation failed"
+    assert a.dtype == "float32", "Inferred dtype failed"
+
+
+def test_numarray_creation_from_numarray_f32():
+    a = rnp.NumArray([1.0, 2.0, 3.0], dtype="float32")
+    b = rnp.NumArray(a)
+    # Modify the original NumArray to make sure we are not just copying the reference
+    a += 1
+    b += 1
+    assert a.tolist() == b.tolist(), "NumArray creation from NumArray failed"
+    assert a.dtype == b.dtype, "NumArray creation from NumArray failed"
+
+
+def test_numarray_creation_from_numarray_u8():
+    a = rnp.NumArray([1, 2, 3], dtype="uint8")
+    b = rnp.NumArray(a)
+    # Modify the original NumArray to make sure we are not just copying the reference
+    a += 1
+    b += 1
+    assert a.tolist() == b.tolist(), "NumArray creation from NumArray failed"
+    assert a.dtype == b.dtype, "NumArray creation from NumArray failed"
+
+
 def test_zeros():
     a = rnp.zeros((2, 3), dtype="float32")
     b = np.zeros((2, 3), dtype="float32")
@@ -142,3 +193,45 @@ def test_fancy_index_flipping_u8():
     assert np.allclose(
         a[:, ::-1].tolist(), b[:, ::-1], atol=1e-9
     ), "Fancy indexing failed"
+
+
+def test_fancy_index_flipping_3d_f32():
+    data = [
+        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+        [[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]],
+        [[13.0, 14.0], [15.0, 16.0], [17.0, 18.0]],
+    ]
+
+    a = rnp.NumArray(data, dtype="float32")
+    b = np.array(data, dtype="float32")
+
+    assert np.allclose(
+        a[:, :, ::-1].tolist(), b[:, :, ::-1], atol=1e-9
+    ), "Fancy indexing failed"
+    assert a[:, :, ::-1].shape == b[:, :, ::-1].shape, "Shape mismatch"
+
+    assert np.allclose(
+        a[:, ::-1, :].tolist(), b[:, ::-1, :], atol=1e-9
+    ), "Fancy indexing failed"
+    assert a[:, ::-1, :].shape == b[:, ::-1, :].shape, "Shape mismatch"
+
+
+def test_fancy_index_flipping_3d_u8():
+    data = [
+        [[1, 2], [3, 4], [5, 6]],
+        [[7, 8], [9, 10], [11, 12]],
+        [[13, 14], [15, 16], [17, 18]],
+    ]
+
+    a = rnp.NumArray(data, dtype="uint8")
+    b = np.array(data, dtype="uint8")
+
+    assert np.allclose(
+        a[:, :, ::-1].tolist(), b[:, :, ::-1], atol=1e-9
+    ), "Fancy indexing failed"
+    assert a[:, :, ::-1].shape == b[:, :, ::-1].shape, "Shape mismatch"
+
+    assert np.allclose(
+        a[:, ::-1, :].tolist(), b[:, ::-1, :], atol=1e-9
+    ), "Fancy indexing failed"
+    assert a[:, ::-1, :].shape == b[:, ::-1, :].shape, "Shape mismatch"

--- a/bindings/python/tests/test_basics.py
+++ b/bindings/python/tests/test_basics.py
@@ -96,3 +96,49 @@ def test_concatenate_along_axis_1():
     assert np.allclose(
         rnp.concatenate([a, b], axis=1).tolist(), c, atol=1e-9
     ), "Concatenate failed"
+
+
+def test_flip_axis_0():
+    a = rnp.NumArray([[1.0, 2.0], [3.0, 4.0]], dtype="float32")
+    b = np.flip(np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32"), axis=0)
+    assert np.allclose(a.flip(axis=0).tolist(), b, atol=1e-9), "Flip axis 0 failed"
+    assert a.flip(axis=0).shape == b.shape, "Shape mismatch"
+
+
+def test_flip_axis_1():
+    a = rnp.NumArray([[1.0, 2.0], [3.0, 4.0]], dtype="float32")
+    b = np.flip(np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32"), axis=1)
+    assert np.allclose(a.flip(axis=1).tolist(), b, atol=1e-9), "Flip axis 1 failed"
+    assert a.flip(axis=1).shape == b.shape, "Shape mismatch"
+
+
+def test_flip_multiple_axis():
+    a = rnp.NumArray(
+        [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], dtype="float32"
+    )
+    b = np.flip(
+        np.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], dtype="float32"),
+        axis=(0, 1),
+    )
+    assert np.allclose(
+        a.flip(axis=(0, 1)).tolist(), b, atol=1e-9
+    ), "Flip multiple axis failed"
+    assert a.flip(axis=(0, 1)).shape == b.shape, "Shape mismatch"
+
+
+def test_fancy_index_flipping_f32():
+    a = rnp.NumArray([[1.0, 2.0], [3.0, 4.0]], dtype="float32")
+    b = np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32")
+
+    assert np.allclose(
+        a[:, ::-1].tolist(), b[:, ::-1], atol=1e-9
+    ), "Fancy indexing failed"
+
+
+def test_fancy_index_flipping_u8():
+    a = rnp.NumArray([[1, 2], [3, 4]], dtype="uint8")
+    b = np.array([[1, 2], [3, 4]], dtype="uint8")
+
+    assert np.allclose(
+        a[:, ::-1].tolist(), b[:, ::-1], atol=1e-9
+    ), "Fancy indexing failed"

--- a/rustynum-rs/benches/array_benchmarks.rs
+++ b/rustynum-rs/benches/array_benchmarks.rs
@@ -2,7 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criteri
 use nalgebra::{DMatrix, DVector};
 use ndarray::{Array1, Array2};
 use rustynum_rs::num_array::linalg::matrix_multiply;
-use rustynum_rs::NumArray32; // Adjust this to the path to your library
+use rustynum_rs::NumArrayF32;
 
 // Define the operations you want to benchmark
 enum Operation {
@@ -33,9 +33,9 @@ fn benchmark_vector_operation(c: &mut Criterion, op: Operation, sizes: &[usize])
 
     for &size in sizes {
         // Setup data
-        let a_rustynum = NumArray32::new(create_vector(size));
+        let a_rustynum = NumArrayF32::new(create_vector(size));
         let b_rustynum = if matches!(op, Operation::AddVectors | Operation::DotProduct) {
-            Some(NumArray32::new(create_vector(size)))
+            Some(NumArrayF32::new(create_vector(size)))
         } else {
             None
         };
@@ -128,7 +128,6 @@ fn benchmark_matrix_operation(c: &mut Criterion, op: Operation, sizes: &[usize])
     });
 
     for &size in sizes {
-        // Assuming square matrices for simplicity; adjust as needed
         let rows = size;
         let cols = size;
 
@@ -141,14 +140,14 @@ fn benchmark_matrix_operation(c: &mut Criterion, op: Operation, sizes: &[usize])
         };
         let vector = create_vector(cols);
 
-        let num_array_matrix1 = NumArray32::new_with_shape(matrix1.clone(), vec![rows, cols]);
+        let num_array_matrix1 = NumArrayF32::new_with_shape(matrix1.clone(), vec![rows, cols]);
         let num_array_matrix2 = if let Some(ref m2) = matrix2 {
-            Some(NumArray32::new_with_shape(m2.clone(), vec![cols, rows]))
+            Some(NumArrayF32::new_with_shape(m2.clone(), vec![cols, rows]))
         } else {
             None
         };
         let num_array_vector = if matches!(op, Operation::MatrixVectorMultiplication) {
-            Some(NumArray32::new_with_shape(vector.clone(), vec![cols]))
+            Some(NumArrayF32::new_with_shape(vector.clone(), vec![cols]))
         } else {
             None
         };

--- a/rustynum-rs/src/lib.rs
+++ b/rustynum-rs/src/lib.rs
@@ -14,5 +14,8 @@ pub mod simd_ops;
 
 pub mod traits;
 
-pub use num_array::num_array::NumArray32;
-pub use num_array::num_array::NumArray64;
+pub use num_array::num_array::NumArrayF32;
+pub use num_array::num_array::NumArrayF64;
+pub use num_array::num_array::NumArrayI32;
+pub use num_array::num_array::NumArrayI64;
+pub use num_array::num_array::NumArrayU8;

--- a/rustynum-rs/src/num_array/linalg.rs
+++ b/rustynum-rs/src/num_array/linalg.rs
@@ -1,7 +1,7 @@
 //! # Linear Algebra Operations
 //!
 //! Provides operations such as matrix-vector multiplication using NumArray data structures.
-use super::num_array::{NumArray, NumArray32, NumArray64};
+use super::num_array::NumArray;
 use std::iter::Sum;
 
 use crate::simd_ops::SimdOps;
@@ -155,12 +155,14 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::NumArrayF32;
+
     use super::*;
 
     #[test]
     fn test_matrix_vector_multiply_correct_calculation() {
-        let matrix = NumArray32::new_with_shape(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
-        let vector = NumArray32::new_with_shape(vec![1.0, 2.0, 3.0], vec![3]);
+        let matrix = NumArrayF32::new_with_shape(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
+        let vector = NumArrayF32::new_with_shape(vec![1.0, 2.0, 3.0], vec![3]);
         let result = matrix_multiply(&matrix, &vector);
 
         assert_eq!(result.shape(), &[2]);
@@ -170,16 +172,16 @@ mod tests {
     #[test]
     #[should_panic(expected = "Column count of the matrix must match the length of the vector.")]
     fn test_matrix_vector_multiply_dimension_mismatch() {
-        let matrix = NumArray32::new_with_shape(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
-        let vector = NumArray32::new_with_shape(vec![1.0, 2.0, 3.0, 4.0], vec![4]);
+        let matrix = NumArrayF32::new_with_shape(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
+        let vector = NumArrayF32::new_with_shape(vec![1.0, 2.0, 3.0, 4.0], vec![4]);
 
         let _result = matrix_multiply(&matrix, &vector);
     }
 
     #[test]
     fn test_matrix_vector_multiply_empty_vector() {
-        let matrix = NumArray32::new_with_shape(vec![], vec![2, 0]);
-        let vector = NumArray32::new_with_shape(vec![], vec![0]);
+        let matrix = NumArrayF32::new_with_shape(vec![], vec![2, 0]);
+        let vector = NumArrayF32::new_with_shape(vec![], vec![0]);
 
         let result = matrix_multiply(&matrix, &vector);
 
@@ -189,8 +191,8 @@ mod tests {
 
     #[test]
     fn test_matrix_vector_multiply_single_element() {
-        let matrix = NumArray32::new_with_shape(vec![5.0], vec![1, 1]);
-        let vector = NumArray32::new_with_shape(vec![2.0], vec![1]);
+        let matrix = NumArrayF32::new_with_shape(vec![5.0], vec![1, 1]);
+        let vector = NumArrayF32::new_with_shape(vec![2.0], vec![1]);
 
         let result = matrix_multiply(&matrix, &vector);
 
@@ -200,7 +202,7 @@ mod tests {
 
     #[test]
     fn test_matrix_matrix_multiply_size_16() {
-        let matrix = NumArray32::new_with_shape(
+        let matrix = NumArrayF32::new_with_shape(
             vec![
                 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
                 16.0, 16.0, 15.0, 14.0, 13.0, 12.0, 11.0, 10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0,
@@ -210,7 +212,7 @@ mod tests {
             vec![3, 16],
         );
 
-        let matrix_rhs = NumArray32::new_with_shape(
+        let matrix_rhs = NumArrayF32::new_with_shape(
             vec![
                 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
                 16.0,

--- a/rustynum-rs/src/num_array/operations.rs
+++ b/rustynum-rs/src/num_array/operations.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use super::num_array::{NumArray, NumArray32, NumArray64};
+use super::num_array::{NumArray, NumArrayF32, NumArrayF64, NumArrayI32, NumArrayI64, NumArrayU8};
 use crate::simd_ops::SimdOps;
 use crate::traits::{ExpLog, FromU32, FromUsize, NumOps};
 use std::fmt::Debug;
@@ -481,35 +481,64 @@ where
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
-    /// test for our newly added Add method
+    #[test]
+    fn test_add_scalar_u8() {
+        let a = NumArrayU8::new(vec![1, 2, 3, 4]);
+        let result = a + 1;
+        assert_eq!(result.get_data(), &vec![2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_add_array_u8() {
+        let a = NumArrayU8::new(vec![1, 2, 3, 4]);
+        let b = NumArrayU8::new(vec![4, 3, 2, 1]);
+        let result = a + b;
+        assert_eq!(result.get_data(), &vec![5, 5, 5, 5]);
+    }
+
+    #[test]
+    fn test_add_scalar_i32() {
+        let a = NumArrayI32::new(vec![1, 2, 3, 4]);
+        let result = a + 1;
+        assert_eq!(result.get_data(), &vec![2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_add_scalar_i64() {
+        let a = NumArrayI64::new(vec![1, 2, 3, 4]);
+        let result = a + 1;
+        assert_eq!(result.get_data(), &vec![2, 3, 4, 5]);
+    }
+
     #[test]
     fn test_add_scalar_f32() {
-        let a = NumArray32::new(vec![1.0, 2.0, 3.0, 4.0]);
+        let a = NumArrayF32::new(vec![1.0, 2.0, 3.0, 4.0]);
         let result = a + 1.0;
         assert_eq!(result.get_data(), &vec![2.0, 3.0, 4.0, 5.0]);
     }
 
     #[test]
     fn test_add_scalar_f64() {
-        let a = NumArray64::new(vec![1.0, 2.0, 3.0, 4.0]);
+        let a = NumArrayF64::new(vec![1.0, 2.0, 3.0, 4.0]);
         let result = a + 1.0;
         assert_eq!(result.get_data(), &vec![2.0, 3.0, 4.0, 5.0]);
     }
 
     #[test]
     fn test_add_array_f32() {
-        let a = NumArray32::new(vec![1.0, 2.0, 3.0, 4.0]);
-        let b = NumArray32::new(vec![4.0, 3.0, 2.0, 1.0]);
+        let a = NumArrayF32::new(vec![1.0, 2.0, 3.0, 4.0]);
+        let b = NumArrayF32::new(vec![4.0, 3.0, 2.0, 1.0]);
         let result = a + b;
         assert_eq!(result.get_data(), &vec![5.0, 5.0, 5.0, 5.0]);
     }
 
     #[test]
     fn test_add_array_f64() {
-        let a = NumArray64::new(vec![1.0, 2.0, 3.0, 4.0]);
-        let b = NumArray64::new(vec![4.0, 3.0, 2.0, 1.0]);
+        let a = NumArrayF64::new(vec![1.0, 2.0, 3.0, 4.0]);
+        let b = NumArrayF64::new(vec![4.0, 3.0, 2.0, 1.0]);
         let result = a + b;
         assert_eq!(result.get_data(), &vec![5.0, 5.0, 5.0, 5.0]);
     }
@@ -517,7 +546,7 @@ mod tests {
     #[test]
     fn test_add_scalar_with_remainder() {
         let data = (0..18).map(|x| x as f32).collect::<Vec<_>>(); // Length not divisible by 16 (assuming f32x16)
-        let num_array = NumArray32::new(data);
+        let num_array = NumArrayF32::new(data);
         let scalar = 1.0f32;
 
         let result = num_array + scalar;
@@ -536,8 +565,8 @@ mod tests {
         let data_a = (0..18).map(|x| x as f32).collect::<Vec<_>>(); // Length not divisible by 16
         let data_b = (0..18).map(|x| 2.0 * x as f32).collect::<Vec<_>>();
 
-        let num_array_a = NumArray32::new(data_a);
-        let num_array_b = NumArray32::new(data_b);
+        let num_array_a = NumArrayF32::new(data_a);
+        let num_array_b = NumArrayF32::new(data_b);
 
         let result = num_array_a + num_array_b;
 

--- a/rustynum-rs/src/simd_ops/mod.rs
+++ b/rustynum-rs/src/simd_ops/mod.rs
@@ -1,10 +1,14 @@
 use crate::helpers::parallel::parallel_for_chunks;
+use std::simd::cmp::SimdOrd;
 use std::simd::f32x16;
 use std::simd::f64x8;
 use std::simd::num::SimdFloat;
+use std::simd::num::SimdUint;
+use std::simd::u8x64;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+const LANES_8: usize = 64;
 const LANES_32: usize = 16;
 const LANES_64: usize = 8;
 
@@ -23,6 +27,132 @@ where
     T: std::ops::Mul<Output = T> + std::iter::Sum + Copy,
 {
     a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum()
+}
+
+impl SimdOps<u8> for u8x64 {
+    fn transpose(src: &[u8], dst: &mut [u8], rows: usize, cols: usize) {
+        for i in 0..rows {
+            for j in 0..cols {
+                dst[j * rows + i] = src[i * cols + j];
+            }
+        }
+    }
+
+    fn matrix_multiply(a: &[u8], b: &[u8], c: &mut [u8], m: usize, k: usize, n: usize) {
+        assert_eq!(a.len(), m * k);
+        assert_eq!(b.len(), k * n);
+        assert_eq!(c.len(), m * n);
+
+        c.fill(0);
+
+        let mut b_transposed = vec![0u8; n * k];
+        Self::transpose(b, &mut b_transposed, k, n);
+
+        // We need to use a Mutex to safely write to the shared result matrix
+        let c_shared = Arc::new(Mutex::new(c));
+
+        parallel_for_chunks(0, m, |row_start, row_end| {
+            // Clone the shared result matrix for each thread
+            let c_lock = Arc::clone(&c_shared);
+
+            for i in row_start..row_end {
+                let a_row = &a[i * k..(i + 1) * k];
+                let mut c_row = vec![0u8; n];
+
+                for j in 0..n {
+                    let b_col = &b_transposed[j * k..(j + 1) * k];
+                    c_row[j] = Self::dot_product(a_row, b_col);
+                }
+                //
+                let mut c_guard = c_lock.lock().unwrap();
+                c_guard[i * n..(i + 1) * n].copy_from_slice(&c_row);
+            }
+        });
+    }
+
+    fn dot_product(a: &[u8], b: &[u8]) -> u8 {
+        assert_eq!(a.len(), b.len());
+        let len = a.len();
+
+        let chunks = len / LANES_8;
+
+        let mut sum1 = u8x64::splat(0);
+        let mut sum2 = u8x64::splat(0);
+
+        // Main loop with manual unrolling
+        for i in (0..chunks).step_by(2) {
+            let a1 = u8x64::from_slice(&a[i * LANES_8..]);
+            let b1 = u8x64::from_slice(&b[i * LANES_8..]);
+            sum1 += a1 * b1;
+
+            if i + 1 < chunks {
+                let a2 = u8x64::from_slice(&a[(i + 1) * LANES_8..]);
+                let b2 = u8x64::from_slice(&b[(i + 1) * LANES_8..]);
+                sum2 += a2 * b2;
+            }
+        }
+
+        let mut scalar_sum = (sum1 + sum2).reduce_sum();
+
+        // Efficient tail handling
+        let remainder = len % LANES_8;
+        if remainder > 0 {
+            let tail_start = len - remainder;
+            scalar_sum += dot_product_scalar(&a[tail_start..], &b[tail_start..]);
+        }
+
+        scalar_sum
+    }
+
+    fn sum(a: &[u8]) -> u8 {
+        let mut sum = u8x64::splat(0);
+        let chunks = a.len() / 64;
+
+        for i in 0..chunks {
+            let simd_chunk = u8x64::from_slice(&a[i * 64..]);
+            sum += simd_chunk;
+        }
+
+        let mut scalar_sum = sum.reduce_sum();
+        // Sum any remaining elements that didn't fit into a SIMD chunk
+        for i in (chunks * LANES_8)..a.len() {
+            scalar_sum += a[i];
+        }
+
+        scalar_sum
+    }
+
+    fn min(a: &[u8]) -> u8 {
+        let simd_min_initial_value = u8::MAX;
+        let mut simd_min = u8x64::splat(simd_min_initial_value);
+        let chunks = a.len() / LANES_8;
+        for i in 0..chunks {
+            let simd_chunk = u8x64::from_slice(&a[i * LANES_8..]);
+            simd_min = simd_min.simd_min(simd_chunk);
+        }
+        let mut final_min = simd_min.reduce_min();
+        // Handle remaining elements
+        for i in chunks * LANES_8..a.len() {
+            final_min = final_min.min(a[i]);
+        }
+        final_min
+    }
+
+    fn max(a: &[u8]) -> u8 {
+        let simd_max_initial_value = u8::MIN;
+        let mut simd_max = u8x64::splat(simd_max_initial_value);
+        let chunks = a.len() / LANES_8;
+        for i in 0..chunks {
+            let simd_chunk = u8x64::from_slice(&a[i * LANES_8..]);
+            simd_max = simd_max.simd_max(simd_chunk);
+        }
+        let mut final_max = simd_max.reduce_max();
+        // Handle remaining elements
+        for i in chunks * LANES_8..a.len() {
+            final_max = final_max.max(a[i]);
+        }
+        final_max
+    }
 }
 
 impl SimdOps<f32> for f32x16 {
@@ -307,6 +437,14 @@ mod tests {
     }
 
     #[test]
+    fn test_dot_product_u8() {
+        let a = [1, 2, 3, 4, 5, 6, 7, 8];
+        let b = [8, 7, 6, 5, 4, 3, 2, 1];
+        let result = u8x64::dot_product(&a, &b);
+        assert_eq!(result, 120);
+    }
+
+    #[test]
     fn test_matrix_multiply_small_known_result_f32() {
         let a = vec![
             1.0, 2.0, 3.0, // 2x3 matrix
@@ -325,6 +463,28 @@ mod tests {
         f32x16::matrix_multiply(&a, &b, &mut c, m, k, n);
 
         let expected = vec![58.0, 64.0, 139.0, 154.0];
+        assert_eq!(c, expected);
+    }
+
+    #[test]
+    fn test_matrix_multiply_small_known_result_u8() {
+        let a = vec![
+            1, 2, 3, // 2x3 matrix
+            4, 5, 6,
+        ];
+        let b = vec![
+            7, 8, // 3x2 matrix
+            9, 10, 11, 12,
+        ];
+        let mut c = vec![0; 4]; // Result will be 2x2 matrix
+
+        let m = 2;
+        let k = 3;
+        let n = 2;
+
+        u8x64::matrix_multiply(&a, &b, &mut c, m, k, n);
+
+        let expected = vec![58, 64, 139, 154];
         assert_eq!(c, expected);
     }
 

--- a/rustynum-rs/src/traits.rs
+++ b/rustynum-rs/src/traits.rs
@@ -70,6 +70,22 @@ impl FromU32 for f64 {
     }
 }
 
+/// Converts an unsigned 32-bit integer to an unsigned 8-bit integer.
+impl FromU32 for u8 {
+    /// Converts the given `value` of type `u32` to an unsigned 8-bit integer (`u8`).
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The unsigned 32-bit integer value to convert.
+    ///
+    /// # Returns
+    ///
+    /// The converted unsigned 8-bit integer value.
+    fn from_u32(value: u32) -> Self {
+        value as u8
+    }
+}
+
 /// Converts an unsigned 32-bit integer to a signed 32-bit integer.
 impl FromU32 for i32 {
     /// Converts the given `value` of type `u32` to a signed 32-bit integer (`i32`).
@@ -140,6 +156,26 @@ impl FromUsize for f64 {
     }
 }
 
+/// Converts a `usize` value to `u8` value.
+///
+/// # Panics
+///
+/// Panics if the `usize` value is too large to fit into a `u8`.
+impl FromUsize for u8 {
+    /// Converts a `usize` value into a `u8` value.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The `usize` value to convert.
+    ///
+    /// # Returns
+    ///
+    /// The converted `u8` value.
+    fn from_usize(value: usize) -> Self {
+        value.try_into().expect("usize value is too large for u8")
+    }
+}
+
 /// Converts a `usize` value into an `i32` value.
 ///
 /// # Panics
@@ -206,7 +242,7 @@ impl NumOps for f64 {
 
 /// Trait implementation for performing numeric operations on `i32`.
 impl NumOps for i32 {
-    /// Calculates the square root of the `i32` value.
+    /// Calculates the square root of the `i32` value.  
     fn sqrt(self) -> Self {
         (self as f64).sqrt() as i32
     }

--- a/rustynum-rs/tests/integration_tests.rs
+++ b/rustynum-rs/tests/integration_tests.rs
@@ -1,10 +1,10 @@
-use rustynum_rs::{NumArray32, NumArray64};
+use rustynum_rs::{NumArrayF32, NumArrayF64};
 
 #[test]
 fn test_num_array_creation_and_dot_product() {
     // Create two `NumArray` instances with test data.
-    let array1 = NumArray32::from(&[1.0, 2.0, 3.0, 4.0][..]);
-    let array2 = NumArray32::from(vec![4.0, 3.0, 2.0, 1.0]);
+    let array1 = NumArrayF32::from(&[1.0, 2.0, 3.0, 4.0][..]);
+    let array2 = NumArrayF32::from(vec![4.0, 3.0, 2.0, 1.0]);
 
     // Perform a dot product operation between the two arrays.
     let result = array1.dot(&array2);
@@ -17,8 +17,8 @@ fn test_num_array_creation_and_dot_product() {
     );
 
     // Test with arrays of different sizes to ensure it handles non-multiples of SIMD width
-    let array3 = NumArray32::from(&[1.0, 2.0, 3.0][..]);
-    let array4 = NumArray32::from(vec![4.0, 5.0, 6.0]);
+    let array3 = NumArrayF32::from(&[1.0, 2.0, 3.0][..]);
+    let array4 = NumArrayF32::from(vec![4.0, 5.0, 6.0]);
 
     // Perform a dot product operation between the two smaller arrays.
     let result_small = array3.dot(&array4);
@@ -42,8 +42,8 @@ fn test_complex_operations() {
     let step = size as f64 / (size - 1) as f64; // Correct step calculation
     let data2: Vec<f64> = (0..size).map(|x| size as f64 - x as f64 * step).collect();
 
-    let array1 = NumArray64::from(data1.clone());
-    let array2 = NumArray64::from(data2.clone());
+    let array1 = NumArrayF64::from(data1.clone());
+    let array2 = NumArrayF64::from(data2.clone());
 
     // Perform addition of two NumArrays
     let added = &array1 + &array2;


### PR DESCRIPTION
- Add experimental support for u8 datatype (basic stuff like array creation should work fine)
- Add flip method
  - In Python bindings one can now do fancy flipping `rnp.array([1,2,3])[::-1]`
- Fix a tolist bug