### PR TITLE
Rename axes as argument to axis to match numpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,16 +162,16 @@ Computes the dot product with another NumArray.
 dot_product = a.dot(b)
 ```
 
-`mean(axes: Union[None, int, Sequence[int]] = None) -> Union[NumArray, float]`
+`mean(axis: Union[None, int, Sequence[int]] = None) -> Union[NumArray, float]`
 
-Computes the mean along specified axes.
+Computes the mean along specified axis.
 
 ```Python
 average = a.mean()
-average_axis0 = a.mean(axes=0)
+average_axis0 = a.mean(axis=0)
 ```
 
-`min() -> float`
+`min(axis: Union[None, int, Sequence[int]] = None) -> Union[NumArray, float]`
 
 Returns the minimum value in the array.
 
@@ -179,7 +179,7 @@ Returns the minimum value in the array.
 minimum = a.min()
 ```
 
-`max() -> float`
+`max(axis: Union[None, int, Sequence[int]] = None) -> Union[NumArray, float]`
 
 Returns the maximum value in the array.
 

--- a/bindings/python/rustynum/__init__.py
+++ b/bindings/python/rustynum/__init__.py
@@ -1,8 +1,9 @@
 # rustynum_py_wrapper/__init__.py
-from . import _rustynum
-from typing import Any, List, Sequence, Tuple, Union
 import itertools
 import math
+from typing import Any, List, Sequence, Tuple, Union
+
+from . import _rustynum
 
 
 class NumArray:
@@ -326,81 +327,81 @@ class NumArray:
         return NumArray(result, dtype=self.dtype)
 
     def mean(
-        self, axes: Union[None, int, Sequence[int]] = None
+        self, axis: Union[None, int, Sequence[int]] = None
     ) -> Union["NumArray", float]:
         """
-        Computes the mean of the NumArray along specified axes.
+        Computes the mean of the NumArray along specified axis.
 
         Parameters:
-            axes: Optional; Axis or axes along which to compute the mean. If None, the mean
+            axis: Optional; Axis or axis along which to compute the mean. If None, the mean
                   of all elements is computed as a scalar.
 
         Returns:
-            A new NumArray with the mean values along the specified axes, or a scalar if no axes are given.
+            A new NumArray with the mean values along the specified axis, or a scalar if no axis are given.
         """
-        axes = [axes] if isinstance(axes, int) else axes
+        axis = [axis] if isinstance(axis, int) else axis
         result = (
-            _rustynum.mean_f32(self.inner, axes)
+            _rustynum.mean_f32(self.inner, axis)
             if self.dtype == "float32"
-            else _rustynum.mean_f64(self.inner, axes)
+            else _rustynum.mean_f64(self.inner, axis)
         )
         return NumArray(result, dtype=self.dtype)
 
     def min(
-        self, axes: Union[None, int, Sequence[int]] = None
+        self, axis: Union[None, int, Sequence[int]] = None
     ) -> Union["NumArray", float]:
         """
-        Return the minimum along the specified axes.
+        Return the minimum along the specified axis.
 
         Parameters:
-            axes: Optional; Axis or axes along which to find the minimum. If None,
+            axis: Optional; Axis or axis along which to find the minimum. If None,
                   the minimum of all elements is computed as a scalar.
 
         Returns:
-            A new NumArray with the minimum values along the specified axes,
-            or a scalar if no axes are given.
+            A new NumArray with the minimum values along the specified axis,
+            or a scalar if no axis are given.
         """
-        if axes is None:
+        if axis is None:
             return (
                 _rustynum.min_f32(self.inner)
                 if self.dtype == "float32"
                 else _rustynum.min_f64(self.inner)
             )
 
-        axes = [axes] if isinstance(axes, int) else axes
+        axis = [axis] if isinstance(axis, int) else axis
         result = (
-            _rustynum.min_axes_f32(self.inner, axes)
+            _rustynum.min_axis_f32(self.inner, axis)
             if self.dtype == "float32"
-            else _rustynum.min_axes_f64(self.inner, axes)
+            else _rustynum.min_axis_f64(self.inner, axis)
         )
         return NumArray(result, dtype=self.dtype)
 
     def max(
-        self, axes: Union[None, int, Sequence[int]] = None
+        self, axis: Union[None, int, Sequence[int]] = None
     ) -> Union["NumArray", float]:
         """
-        Return the maximum along the specified axes.
+        Return the maximum along the specified axis.
 
         Parameters:
-            axes: Optional; Axis or axes along which to find the maximum. If None,
+            axis: Optional; Axis or axis along which to find the maximum. If None,
                   the maximum of all elements is computed as a scalar.
 
         Returns:
-            A new NumArray with the maximum values along the specified axes,
-            or a scalar if no axes are given.
+            A new NumArray with the maximum values along the specified axis,
+            or a scalar if no axis are given.
         """
-        if axes is None:
+        if axis is None:
             return (
                 _rustynum.max_f32(self.inner)
                 if self.dtype == "float32"
                 else _rustynum.max_f64(self.inner)
             )
 
-        axes = [axes] if isinstance(axes, int) else axes
+        axis = [axis] if isinstance(axis, int) else axis
         result = (
-            _rustynum.max_axes_f32(self.inner, axes)
+            _rustynum.max_axis_f32(self.inner, axis)
             if self.dtype == "float32"
-            else _rustynum.max_axes_f64(self.inner, axes)
+            else _rustynum.max_axis_f64(self.inner, axis)
         )
         return NumArray(result, dtype=self.dtype)
 
@@ -571,7 +572,7 @@ class NumArray:
 
     def flip(self, axis: Union[int, Sequence[int]]) -> "NumArray":
         """
-        Flips the NumArray along the specified axes.
+        Flips the NumArray along the specified axis.
 
         Parameters:
             axis: Axis to flip along.
@@ -580,9 +581,9 @@ class NumArray:
             A new NumArray with the flipped data.
         """
         if isinstance(axis, int):
-            result = self.inner.flip_axes([axis])
+            result = self.inner.flip_axis([axis])
         elif isinstance(axis, (list, tuple)):
-            result = self.inner.flip_axes(list(axis))
+            result = self.inner.flip_axis(list(axis))
         else:
             raise TypeError("axis must be an integer or a sequence of integers")
         return NumArray(result, dtype=self.dtype)

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -108,12 +108,12 @@ impl PyNumArrayF32 {
         })
     }
 
-    fn mean_axes(&self, axes: Option<&PyList>) -> PyResult<PyNumArrayF32> {
+    fn mean_axis(&self, axis: Option<&PyList>) -> PyResult<PyNumArrayF32> {
         Python::with_gil(|py| {
-            let result = match axes {
-                Some(axes_list) => {
-                    let axes_vec: Vec<usize> = axes_list.extract()?; // Convert PyList to Vec<usize>
-                    self.inner.mean_axes(Some(&axes_vec)) // Now correctly passing a slice wrapped in Some
+            let result = match axis {
+                Some(axis_list) => {
+                    let axis_vec: Vec<usize> = axis_list.extract()?; // Convert PyList to Vec<usize>
+                    self.inner.mean_axis(Some(&axis_vec)) // Now correctly passing a slice wrapped in Some
                 }
                 None => self.inner.mean(),
             };
@@ -145,16 +145,16 @@ impl PyNumArrayF32 {
         })
     }
 
-    fn flip_axes(&self, axes: Option<&PyList>) -> PyResult<PyNumArrayF32> {
+    fn flip_axis(&self, axis: Option<&PyList>) -> PyResult<PyNumArrayF32> {
         Python::with_gil(|py| {
-            let axes_vec: Vec<usize> = match axes {
+            let axis_vec: Vec<usize> = match axis {
                 Some(list) => list.extract()?,
                 None => vec![],
             };
-            let result = if axes_vec.is_empty() {
+            let result = if axis_vec.is_empty() {
                 self.inner.clone()
             } else {
-                self.inner.flip_axes(axes_vec)
+                self.inner.flip_axis(axis_vec)
             };
             Ok(PyNumArrayF32 { inner: result })
         })
@@ -178,27 +178,27 @@ impl PyNumArrayF32 {
         }
     }
 
-    fn min_axes(&self, axes: Option<&PyList>) -> PyResult<PyNumArrayF32> {
+    fn min_axis(&self, axis: Option<&PyList>) -> PyResult<PyNumArrayF32> {
         Python::with_gil(|py| {
-            let result = match axes {
-                Some(axes_list) => {
-                    let axes_vec: Vec<usize> = axes_list.extract()?;
-                    self.inner.min_axes(Some(&axes_vec))
+            let result = match axis {
+                Some(axis_list) => {
+                    let axis_vec: Vec<usize> = axis_list.extract()?;
+                    self.inner.min_axis(Some(&axis_vec))
                 }
-                None => self.inner.min_axes(None),
+                None => self.inner.min_axis(None),
             };
             Ok(PyNumArrayF32 { inner: result })
         })
     }
 
-    fn max_axes(&self, axes: Option<&PyList>) -> PyResult<PyNumArrayF32> {
+    fn max_axis(&self, axis: Option<&PyList>) -> PyResult<PyNumArrayF32> {
         Python::with_gil(|py| {
-            let result = match axes {
-                Some(axes_list) => {
-                    let axes_vec: Vec<usize> = axes_list.extract()?;
-                    self.inner.max_axes(Some(&axes_vec))
+            let result = match axis {
+                Some(axis_list) => {
+                    let axis_vec: Vec<usize> = axis_list.extract()?;
+                    self.inner.max_axis(Some(&axis_vec))
                 }
-                None => self.inner.max_axes(None),
+                None => self.inner.max_axis(None),
             };
             Ok(PyNumArrayF32 { inner: result })
         })
@@ -277,14 +277,14 @@ impl PyNumArrayF64 {
         })
     }
 
-    fn mean_axes(&self, axes: Option<&PyList>) -> PyResult<PyNumArrayF64> {
+    fn mean_axis(&self, axis: Option<&PyList>) -> PyResult<PyNumArrayF64> {
         Python::with_gil(|py| {
-            let result = match axes {
-                Some(axes_list) => {
-                    let axes_vec: Vec<usize> = axes_list.extract()?; // Convert PyList to Vec<usize>
-                    self.inner.mean_axes(Some(&axes_vec)) // Now correctly passing a slice wrapped in Some
+            let result = match axis {
+                Some(axis_list) => {
+                    let axis_vec: Vec<usize> = axis_list.extract()?; // Convert PyList to Vec<usize>
+                    self.inner.mean_axis(Some(&axis_vec)) // Now correctly passing a slice wrapped in Some
                 }
-                None => self.inner.mean_axes(None),
+                None => self.inner.mean_axis(None),
             };
             Ok(PyNumArrayF64 { inner: result })
         })
@@ -314,16 +314,16 @@ impl PyNumArrayF64 {
         })
     }
 
-    fn flip_axes(&self, axes: Option<&PyList>) -> PyResult<PyNumArrayF64> {
+    fn flip_axis(&self, axis: Option<&PyList>) -> PyResult<PyNumArrayF64> {
         Python::with_gil(|py| {
-            let axes_vec: Vec<usize> = match axes {
+            let axis_vec: Vec<usize> = match axis {
                 Some(list) => list.extract()?,
                 None => vec![],
             };
-            let result = if axes_vec.is_empty() {
+            let result = if axis_vec.is_empty() {
                 self.inner.clone()
             } else {
-                self.inner.flip_axes(axes_vec)
+                self.inner.flip_axis(axis_vec)
             };
             Ok(PyNumArrayF64 { inner: result })
         })
@@ -347,27 +347,27 @@ impl PyNumArrayF64 {
         }
     }
 
-    fn min_axes(&self, axes: Option<&PyList>) -> PyResult<PyNumArrayF64> {
+    fn min_axis(&self, axis: Option<&PyList>) -> PyResult<PyNumArrayF64> {
         Python::with_gil(|py| {
-            let result = match axes {
-                Some(axes_list) => {
-                    let axes_vec: Vec<usize> = axes_list.extract()?;
-                    self.inner.min_axes(Some(&axes_vec))
+            let result = match axis {
+                Some(axis_list) => {
+                    let axis_vec: Vec<usize> = axis_list.extract()?;
+                    self.inner.min_axis(Some(&axis_vec))
                 }
-                None => self.inner.min_axes(None),
+                None => self.inner.min_axis(None),
             };
             Ok(PyNumArrayF64 { inner: result })
         })
     }
 
-    fn max_axes(&self, axes: Option<&PyList>) -> PyResult<PyNumArrayF64> {
+    fn max_axis(&self, axis: Option<&PyList>) -> PyResult<PyNumArrayF64> {
         Python::with_gil(|py| {
-            let result = match axes {
-                Some(axes_list) => {
-                    let axes_vec: Vec<usize> = axes_list.extract()?;
-                    self.inner.max_axes(Some(&axes_vec))
+            let result = match axis {
+                Some(axis_list) => {
+                    let axis_vec: Vec<usize> = axis_list.extract()?;
+                    self.inner.max_axis(Some(&axis_vec))
                 }
-                None => self.inner.max_axes(None),
+                None => self.inner.max_axis(None),
             };
             Ok(PyNumArrayF64 { inner: result })
         })
@@ -465,16 +465,16 @@ impl PyNumArrayU8 {
         })
     }
 
-    fn flip_axes(&self, axes: Option<&PyList>) -> PyResult<PyNumArrayU8> {
+    fn flip_axis(&self, axis: Option<&PyList>) -> PyResult<PyNumArrayU8> {
         Python::with_gil(|py| {
-            let axes_vec: Vec<usize> = match axes {
+            let axis_vec: Vec<usize> = match axis {
                 Some(list) => list.extract()?,
                 None => vec![],
             };
-            let result = if axes_vec.is_empty() {
+            let result = if axis_vec.is_empty() {
                 self.inner.clone()
             } else {
-                self.inner.flip_axes(axes_vec)
+                self.inner.flip_axis(axis_vec)
             };
             Ok(PyNumArrayU8 { inner: result })
         })
@@ -572,16 +572,16 @@ impl PyNumArrayU8 {
 //         })
 //     }
 
-//     fn flip_axes(&self, axes: Option<&PyList>) -> PyResult<PyNumArrayI32> {
+//     fn flip_axis(&self, axis: Option<&PyList>) -> PyResult<PyNumArrayI32> {
 //         Python::with_gil(|py| {
-//             let axes_vec: Vec<usize> = match axes {
+//             let axis_vec: Vec<usize> = match axis {
 //                 Some(list) => list.extract()?,
 //                 None => vec![],
 //             };
-//             let result = if axes_vec.is_empty() {
+//             let result = if axis_vec.is_empty() {
 //                 self.inner.clone()
 //             } else {
-//                 self.inner.flip_axes(axes_vec)
+//                 self.inner.flip_axis(axis_vec)
 //             };
 //             Ok(PyNumArrayI32 { inner: result })
 //         })
@@ -655,14 +655,14 @@ impl PyNumArrayU8 {
 //         })
 //     }
 
-//     fn mean_axes(&self, axes: Option<&PyList>) -> PyResult<PyNumArrayI64> {
+//     fn mean_axis(&self, axis: Option<&PyList>) -> PyResult<PyNumArrayI64> {
 //         Python::with_gil(|py| {
-//             let result = match axes {
-//                 Some(axes_list) => {
-//                     let axes_vec: Vec<usize> = axes_list.extract()?; // Convert PyList to Vec<usize>
-//                     self.inner.mean_axes(Some(&axes_vec)) // Now correctly passing a slice wrapped in Some
+//             let result = match axis {
+//                 Some(axis_list) => {
+//                     let axis_vec: Vec<usize> = axis_list.extract()?; // Convert PyList to Vec<usize>
+//                     self.inner.mean_axis(Some(&axis_vec)) // Now correctly passing a slice wrapped in Some
 //                 }
-//                 None => self.inner.mean_axes(None),
+//                 None => self.inner.mean_axis(None),
 //             };
 //             Ok(PyNumArrayI64 { inner: result })
 //         })
@@ -692,16 +692,16 @@ impl PyNumArrayU8 {
 //         })
 //     }
 
-//     fn flip_axes(&self, axes: Option<&PyList>) -> PyResult<PyNumArrayI64> {
+//     fn flip_axis(&self, axis: Option<&PyList>) -> PyResult<PyNumArrayI64> {
 //         Python::with_gil(|py| {
-//             let axes_vec: Vec<usize> = match axes {
+//             let axis_vec: Vec<usize> = match axis {
 //                 Some(list) => list.extract()?,
 //                 None => vec![],
 //             };
-//             let result = if axes_vec.is_empty() {
+//             let result = if axis_vec.is_empty() {
 //                 self.inner.clone()
 //             } else {
-//                 self.inner.flip_axes(axes_vec)
+//                 self.inner.flip_axis(axis_vec)
 //             };
 //             Ok(PyNumArrayI64 { inner: result })
 //         })
@@ -780,14 +780,14 @@ fn linspace_f32(start: f32, end: f32, num: usize) -> PyResult<PyNumArrayF32> {
 }
 
 #[pyfunction]
-fn mean_f32(a: &PyNumArrayF32, axes: Option<&PyList>) -> PyResult<PyNumArrayF32> {
+fn mean_f32(a: &PyNumArrayF32, axis: Option<&PyList>) -> PyResult<PyNumArrayF32> {
     Python::with_gil(|py| {
-        let result = match axes {
-            Some(axes_list) => {
-                let axes_vec: Vec<usize> = axes_list.extract()?; // Convert PyList to Vec<usize>
-                a.inner.mean_axes(Some(&axes_vec))
+        let result = match axis {
+            Some(axis_list) => {
+                let axis_vec: Vec<usize> = axis_list.extract()?; // Convert PyList to Vec<usize>
+                a.inner.mean_axis(Some(&axis_vec))
             }
-            None => a.inner.mean_axes(None), // Handle the case where no axes are provided
+            None => a.inner.mean_axis(None), // Handle the case where no axis are provided
         };
         Ok(PyNumArrayF32 { inner: result }) // Convert the result data to a Python object
     })
@@ -799,13 +799,13 @@ fn min_f32(a: &PyNumArrayF32) -> PyResult<f32> {
 }
 
 #[pyfunction]
-fn min_axes_f32(a: &PyNumArrayF32, axes: Option<&PyList>) -> PyResult<PyNumArrayF32> {
-    let result = match axes {
-        Some(axes_list) => {
-            let axes_vec: Vec<usize> = axes_list.extract()?; // Convert PyList to Vec<usize>
-            a.inner.min_axes(Some(&axes_vec))
+fn min_axis_f32(a: &PyNumArrayF32, axis: Option<&PyList>) -> PyResult<PyNumArrayF32> {
+    let result = match axis {
+        Some(axis_list) => {
+            let axis_vec: Vec<usize> = axis_list.extract()?; // Convert PyList to Vec<usize>
+            a.inner.min_axis(Some(&axis_vec))
         }
-        None => a.inner.min_axes(None),
+        None => a.inner.min_axis(None),
     };
     Ok(PyNumArrayF32 { inner: result })
 }
@@ -816,13 +816,13 @@ fn max_f32(a: &PyNumArrayF32) -> PyResult<f32> {
 }
 
 #[pyfunction]
-fn max_axes_f32(a: &PyNumArrayF32, axes: Option<&PyList>) -> PyResult<PyNumArrayF32> {
-    let result = match axes {
-        Some(axes_list) => {
-            let axes_vec: Vec<usize> = axes_list.extract()?; // Convert PyList to Vec<usize>
-            a.inner.max_axes(Some(&axes_vec))
+fn max_axis_f32(a: &PyNumArrayF32, axis: Option<&PyList>) -> PyResult<PyNumArrayF32> {
+    let result = match axis {
+        Some(axis_list) => {
+            let axis_vec: Vec<usize> = axis_list.extract()?; // Convert PyList to Vec<usize>
+            a.inner.max_axis(Some(&axis_vec))
         }
-        None => a.inner.max_axes(None),
+        None => a.inner.max_axis(None),
     };
     Ok(PyNumArrayF32 { inner: result })
 }
@@ -909,14 +909,14 @@ fn linspace_f64(start: f64, end: f64, num: usize) -> PyResult<PyNumArrayF64> {
 }
 
 #[pyfunction]
-fn mean_f64(a: &PyNumArrayF64, axes: Option<&PyList>) -> PyResult<Py<PyAny>> {
+fn mean_f64(a: &PyNumArrayF64, axis: Option<&PyList>) -> PyResult<Py<PyAny>> {
     Python::with_gil(|py| {
-        let result = match axes {
-            Some(axes_list) => {
-                let axes_vec: Vec<usize> = axes_list.extract()?; // Convert PyList to Vec<usize>
-                a.inner.mean_axes(Some(&axes_vec))
+        let result = match axis {
+            Some(axis_list) => {
+                let axis_vec: Vec<usize> = axis_list.extract()?; // Convert PyList to Vec<usize>
+                a.inner.mean_axis(Some(&axis_vec))
             }
-            None => a.inner.mean_axes(None), // Handle the case where no axes are provided
+            None => a.inner.mean_axis(None), // Handle the case where no axis are provided
         };
         Ok(result.get_data().to_object(py)) // Convert the result data to a Python object
     })
@@ -928,13 +928,13 @@ fn min_f64(a: &PyNumArrayF64) -> PyResult<f64> {
 }
 
 #[pyfunction]
-fn min_axes_f64(a: &PyNumArrayF64, axes: Option<&PyList>) -> PyResult<PyNumArrayF64> {
-    let result = match axes {
-        Some(axes_list) => {
-            let axes_vec: Vec<usize> = axes_list.extract()?; // Convert PyList to Vec<usize>
-            a.inner.min_axes(Some(&axes_vec))
+fn min_axis_f64(a: &PyNumArrayF64, axis: Option<&PyList>) -> PyResult<PyNumArrayF64> {
+    let result = match axis {
+        Some(axis_list) => {
+            let axis_vec: Vec<usize> = axis_list.extract()?; // Convert PyList to Vec<usize>
+            a.inner.min_axis(Some(&axis_vec))
         }
-        None => a.inner.min_axes(None),
+        None => a.inner.min_axis(None),
     };
     Ok(PyNumArrayF64 { inner: result })
 }
@@ -945,13 +945,13 @@ fn max_f64(a: &PyNumArrayF64) -> PyResult<f64> {
 }
 
 #[pyfunction]
-fn max_axes_f64(a: &PyNumArrayF64, axes: Option<&PyList>) -> PyResult<PyNumArrayF64> {
-    let result = match axes {
-        Some(axes_list) => {
-            let axes_vec: Vec<usize> = axes_list.extract()?; // Convert PyList to Vec<usize>
-            a.inner.max_axes(Some(&axes_vec))
+fn max_axis_f64(a: &PyNumArrayF64, axis: Option<&PyList>) -> PyResult<PyNumArrayF64> {
+    let result = match axis {
+        Some(axis_list) => {
+            let axis_vec: Vec<usize> = axis_list.extract()?; // Convert PyList to Vec<usize>
+            a.inner.max_axis(Some(&axis_vec))
         }
-        None => a.inner.max_axes(None),
+        None => a.inner.max_axis(None),
     };
     Ok(PyNumArrayF64 { inner: result })
 }
@@ -998,9 +998,9 @@ fn _rustynum(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(linspace_f32, m)?)?;
     m.add_function(wrap_pyfunction!(mean_f32, m)?)?;
     m.add_function(wrap_pyfunction!(min_f32, m)?)?;
-    m.add_function(wrap_pyfunction!(min_axes_f32, m)?)?;
+    m.add_function(wrap_pyfunction!(min_axis_f32, m)?)?;
     m.add_function(wrap_pyfunction!(max_f32, m)?)?;
-    m.add_function(wrap_pyfunction!(max_axes_f32, m)?)?;
+    m.add_function(wrap_pyfunction!(max_axis_f32, m)?)?;
     m.add_function(wrap_pyfunction!(exp_f32, m)?)?;
     m.add_function(wrap_pyfunction!(log_f32, m)?)?;
     m.add_function(wrap_pyfunction!(sigmoid_f32, m)?)?;

--- a/bindings/python/tests/test_mean.py
+++ b/bindings/python/tests/test_mean.py
@@ -37,7 +37,7 @@ def test_mean_f32_random():
     ), "Mean for f32 failed with error"
 
 
-def test_mean_f32_axes():
+def test_mean_f32_axis():
     # Create a 2D array and wrap it in NumArray
     a = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], dtype=np.float32)
     a_py = rnp.NumArray(a.tolist(), dtype="float32")
@@ -45,9 +45,9 @@ def test_mean_f32_axes():
     a = a.reshape((2, 3))
     a_py = a_py.reshape([2, 3])
 
-    # Compute means along different axes
-    result_rusty_axis0 = a_py.mean(axes=0)
-    result_rusty_axis1 = a_py.mean(axes=1)
+    # Compute means along different axis
+    result_rusty_axis0 = a_py.mean(axis=0)
+    result_rusty_axis1 = a_py.mean(axis=1)
     result_numpy_axis0 = np.mean(a, axis=0)
     result_numpy_axis1 = np.mean(a, axis=1)
 

--- a/bindings/python/tests/test_min_max.py
+++ b/bindings/python/tests/test_min_max.py
@@ -37,52 +37,52 @@ def test_max_f32_small():
     ), "Max for f32 failed with error"
 
 
-def test_min_axes_2d():
-    # Test min along different axes of a 2D array
+def test_min_axis_2d():
+    # Test min along different axis of a 2D array
     a = [[1.0, 2.0], [3.0, 4.0]]
     a_py = rnp.NumArray(a, dtype="float32")
 
     # Test min along axis 0 (columns)
-    result_axis0 = a_py.min(axes=0)
+    result_axis0 = a_py.min(axis=0)
     expected_axis0 = rnp.NumArray([1.0, 2.0], dtype="float32")
     assert result_axis0.tolist() == expected_axis0.tolist(), "Min along axis 0 failed"
 
     # Test min along axis 1 (rows)
-    result_axis1 = a_py.min(axes=1)
+    result_axis1 = a_py.min(axis=1)
     expected_axis1 = rnp.NumArray([1.0, 3.0], dtype="float32")
     assert result_axis1.tolist() == expected_axis1.tolist(), "Min along axis 1 failed"
 
 
-def test_max_axes_2d():
-    # Test max along different axes of a 2D array
+def test_max_axis_2d():
+    # Test max along different axis of a 2D array
     a = [[1.0, 2.0], [3.0, 4.0]]
     a_py = rnp.NumArray(a, dtype="float32")
 
     # Test max along axis 0 (columns)
-    result_axis0 = a_py.max(axes=0)
+    result_axis0 = a_py.max(axis=0)
     expected_axis0 = rnp.NumArray([3.0, 4.0], dtype="float32")
     assert result_axis0.tolist() == expected_axis0.tolist(), "Max along axis 0 failed"
 
     # Test max along axis 1 (rows)
-    result_axis1 = a_py.max(axes=1)
+    result_axis1 = a_py.max(axis=1)
     expected_axis1 = rnp.NumArray([2.0, 4.0], dtype="float32")
     assert result_axis1.tolist() == expected_axis1.tolist(), "Max along axis 1 failed"
 
 
 def test_min_max_3d():
-    # Test min/max with 3D array and multiple axes
+    # Test min/max with 3D array and multiple axis
     a = [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]
     a_py = rnp.NumArray(a, dtype="float32")
 
-    # Test min along axes (0,1)
-    result_min = a_py.min(axes=[0, 1])
+    # Test min along axis (0,1)
+    result_min = a_py.min(axis=[0, 1])
     expected_min = rnp.NumArray([1.0, 2.0], dtype="float32")
-    assert result_min.tolist() == expected_min.tolist(), "Min along axes (0,1) failed"
+    assert result_min.tolist() == expected_min.tolist(), "Min along axis (0,1) failed"
 
-    # Test max along axes (1,2)
-    result_max = a_py.max(axes=[1, 2])
+    # Test max along axis (1,2)
+    result_max = a_py.max(axis=[1, 2])
     expected_max = rnp.NumArray([4.0, 8.0], dtype="float32")
-    assert result_max.tolist() == expected_max.tolist(), "Max along axes (1,2) failed"
+    assert result_max.tolist() == expected_max.tolist(), "Max along axis (1,2) failed"
 
 
 def test_min_max_edge_cases():
@@ -95,7 +95,7 @@ def test_min_max_edge_cases():
 
     # Empty axis reduction
     a_empty_axis = rnp.NumArray([[1.0], [2.0]], dtype="float32")
-    result_min = a_empty_axis.min(axes=1)
+    result_min = a_empty_axis.min(axis=1)
     assert result_min.tolist() == [1.0, 2.0], "Min failed for empty axis reduction"
 
     # Test with negative values

--- a/rustynum-rs/src/num_array/num_array.rs
+++ b/rustynum-rs/src/num_array/num_array.rs
@@ -209,24 +209,24 @@ where
         NumArray::new_with_shape(self.data.clone(), new_shape.clone())
     }
 
-    /// Reverses the elements along the specified axis or axes.
+    /// Reverses the elements along the specified axis or axis.
     ///
     /// # Parameters
-    /// * `axes` - An iterable of axes along which to reverse the array.
+    /// * `axis` - An iterable of axis along which to reverse the array.
     ///
     /// # Returns
-    /// A new `NumArray` instance with the array reversed along the specified axes.
+    /// A new `NumArray` instance with the array reversed along the specified axis.
     ///
     /// # Panics
     /// Panics if any axis is out of bounds.
-    pub fn flip_axes<I>(&self, axes: I) -> Self
+    pub fn flip_axis<I>(&self, axis: I) -> Self
     where
         I: IntoIterator<Item = usize>,
     {
         let mut new_data = self.data.clone();
         let new_shape = self.shape.clone();
 
-        for axis in axes {
+        for axis in axis {
             assert!(
                 axis < self.shape.len(),
                 "Axis {} is out of bounds for an array with {} dimensions.",
@@ -362,13 +362,13 @@ where
         reduced_index
     }
 
-    /// Removes axes of length one from the array.
+    /// Removes axis of length one from the array.
     ///
     /// # Parameters
-    /// * `axes` - Optional slice of axes to squeeze. If None, all axes of length 1 are removed.
+    /// * `axis` - Optional slice of axis to squeeze. If None, all axis of length 1 are removed.
     ///
     /// # Returns
-    /// A new `NumArray` instance with the specified axes removed.
+    /// A new `NumArray` instance with the specified axis removed.
     ///
     /// # Panics
     /// Panics if any specified axis is out of bounds or has length greater than 1.
@@ -377,14 +377,14 @@ where
     /// ```
     /// use rustynum_rs::NumArrayF32;
     /// let array = NumArrayF32::new_with_shape(vec![1.0, 2.0], vec![1, 2, 1]);
-    /// let squeezed = array.squeeze(None); // removes all axes of length 1
+    /// let squeezed = array.squeeze(None); // removes all axis of length 1
     /// assert_eq!(squeezed.shape(), &[2]);
     /// ```
-    pub fn squeeze(&self, axes: Option<&[usize]>) -> NumArray<T, Ops> {
-        match axes {
-            Some(specified_axes) => {
-                // Validate axes
-                for &axis in specified_axes {
+    pub fn squeeze(&self, axis: Option<&[usize]>) -> NumArray<T, Ops> {
+        match axis {
+            Some(specified_axis) => {
+                // Validate axis
+                for &axis in specified_axis {
                     assert!(
                         axis < self.shape.len(),
                         "Axis {} is out of bounds for array of dimension {}",
@@ -403,14 +403,14 @@ where
                     .shape
                     .iter()
                     .enumerate()
-                    .filter(|&(i, &dim)| !specified_axes.contains(&i) || dim != 1)
+                    .filter(|&(i, &dim)| !specified_axis.contains(&i) || dim != 1)
                     .map(|(_, &dim)| dim)
                     .collect();
 
                 NumArray::new_with_shape(self.data.clone(), new_shape)
             }
             None => {
-                // Remove all axes of length 1
+                // Remove all axis of length 1
                 let new_shape: Vec<usize> = self
                     .shape
                     .iter()
@@ -496,36 +496,36 @@ where
         NumArray::new(vec![mean])
     }
 
-    /// Computes the mean along the specified axes.
+    /// Computes the mean along the specified axis.
     ///
     /// # Parameters
-    /// * `axes` - An optional reference to a vector of axes to compute the mean along.
+    /// * `axis` - An optional reference to a vector of axis to compute the mean along.
     ///
     /// # Returns
-    /// A new `NumArray` instance containing the mean values along the specified axes.
+    /// A new `NumArray` instance containing the mean values along the specified axis.
     ///
     /// # Panics
-    /// Panics if any of the specified axes is out of bounds.
+    /// Panics if any of the specified axis is out of bounds.
     ///
     /// # Example
     /// ```
     /// use rustynum_rs::NumArrayF32;
     /// let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     /// let array = NumArrayF32::new_with_shape(data, vec![2, 3]);
-    /// let mean_array = array.mean_axes(Some(&[1]));
+    /// let mean_array = array.mean_axis(Some(&[1]));
     /// println!("Mean array: {:?}", mean_array.get_data());
     /// ```
-    pub fn mean_axes(&self, axes: Option<&[usize]>) -> NumArray<T, Ops> {
-        match axes {
-            Some(axes) => {
-                for &axis in axes {
+    pub fn mean_axis(&self, axis: Option<&[usize]>) -> NumArray<T, Ops> {
+        match axis {
+            Some(axis) => {
+                for &axis in axis {
                     assert!(axis < self.shape.len(), "Axis {} out of bounds.", axis);
                 }
 
                 let mut reduced_shape = self.shape.clone();
                 let mut total_elements_to_reduce = 1;
 
-                for &axis in axes {
+                for &axis in axis {
                     total_elements_to_reduce *= self.shape[axis];
                     reduced_shape[axis] = 1; // Marking this axis for reduction
                 }
@@ -669,7 +669,7 @@ where
                 array.shape().len() == ndim,
                 "All arrays must have the same number of dimensions."
             );
-            // Validate that shapes match on all axes except the concatenation axis
+            // Validate that shapes match on all axis except the concatenation axis
             for (i, (&dim_ref, &dim_other)) in
                 reference_shape.iter().zip(array.shape().iter()).enumerate()
             {
@@ -822,34 +822,34 @@ where
         }
     }
 
-    /// Computes the minimum value along the specified axes.
+    /// Computes the minimum value along the specified axis.
     ///
     /// # Parameters
-    /// * `axes` - An optional reference to a vector of axes to compute the minimum along.
+    /// * `axis` - An optional reference to a vector of axis to compute the minimum along.
     ///
     /// # Returns
-    /// A new `NumArray` instance containing the minimum values along the specified axes.
+    /// A new `NumArray` instance containing the minimum values along the specified axis.
     ///
     /// # Panics
-    /// Panics if any of the specified axes is out of bounds.
+    /// Panics if any of the specified axis is out of bounds.
     ///
     /// # Example
     /// ```
     /// use rustynum_rs::NumArrayF32;
     /// let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     /// let array = NumArrayF32::new_with_shape(data, vec![2, 3]);
-    /// let min_array = array.min_axes(Some(&[1]));
+    /// let min_array = array.min_axis(Some(&[1]));
     /// println!("Min array: {:?}", min_array.get_data());
     /// ```
-    pub fn min_axes(&self, axes: Option<&[usize]>) -> NumArray<T, Ops> {
-        match axes {
-            Some(axes) => {
-                for &axis in axes {
+    pub fn min_axis(&self, axis: Option<&[usize]>) -> NumArray<T, Ops> {
+        match axis {
+            Some(axis) => {
+                for &axis in axis {
                     assert!(axis < self.shape.len(), "Axis {} out of bounds.", axis);
                 }
 
                 let mut reduced_shape = self.shape.clone();
-                for &axis in axes {
+                for &axis in axis {
                     reduced_shape[axis] = 1; // Mark this axis for reduction
                 }
 
@@ -868,7 +868,7 @@ where
                     }
                 }
 
-                // Squeeze out axes of size 1
+                // Squeeze out axis of size 1
                 let squeezed_shape = reduced_shape
                     .into_iter()
                     .filter(|&dim| dim != 1)
@@ -877,7 +877,7 @@ where
                 NumArray::new_with_shape(reduced_data, squeezed_shape)
             }
             None => {
-                // If no axes are provided, return the overall min
+                // If no axis are provided, return the overall min
                 NumArray::new(vec![Ops::min_simd(&self.data)])
             }
         }
@@ -1040,34 +1040,34 @@ where
             .collect()
     }
 
-    /// Computes the maximum value along the specified axes.
+    /// Computes the maximum value along the specified axis.
     ///
     /// # Parameters
-    /// * `axes` - An optional reference to a vector of axes to compute the maximum along.
+    /// * `axis` - An optional reference to a vector of axis to compute the maximum along.
     ///
     /// # Returns
-    /// A new `NumArray` instance containing the maximum values along the specified axes.
+    /// A new `NumArray` instance containing the maximum values along the specified axis.
     ///
     /// # Panics
-    /// Panics if any of the specified axes is out of bounds.
+    /// Panics if any of the specified axis is out of bounds.
     ///
     /// # Example
     /// ```
     /// use rustynum_rs::NumArrayF32;
     /// let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     /// let array = NumArrayF32::new_with_shape(data, vec![2, 3]);
-    /// let max_array = array.max_axes(Some(&[1]));
+    /// let max_array = array.max_axis(Some(&[1]));
     /// println!("Max array: {:?}", max_array.get_data());
     /// ```
-    pub fn max_axes(&self, axes: Option<&[usize]>) -> NumArray<T, Ops> {
-        match axes {
-            Some(axes) => {
-                for &axis in axes {
+    pub fn max_axis(&self, axis: Option<&[usize]>) -> NumArray<T, Ops> {
+        match axis {
+            Some(axis) => {
+                for &axis in axis {
                     assert!(axis < self.shape.len(), "Axis {} out of bounds.", axis);
                 }
 
                 let mut reduced_shape = self.shape.clone();
-                for &axis in axes {
+                for &axis in axis {
                     reduced_shape[axis] = 1; // Mark this axis for reduction
                 }
 
@@ -1086,7 +1086,7 @@ where
                     }
                 }
 
-                // Squeeze out axes of size 1
+                // Squeeze out axis of size 1
                 let squeezed_shape = reduced_shape
                     .into_iter()
                     .filter(|&dim| dim != 1)
@@ -1095,7 +1095,7 @@ where
                 NumArray::new_with_shape(reduced_data, squeezed_shape)
             }
             None => {
-                // If no axes are provided, return the overall max
+                // If no axis are provided, return the overall max
                 NumArray::new(vec![Ops::max_simd(&self.data)])
             }
         }
@@ -1545,14 +1545,14 @@ mod tests {
     #[test]
     fn test_flip_array() {
         let array = NumArrayF32::new(vec![1.0, 2.0, 3.0, 4.0]);
-        let flipped_array = array.flip_axes([0]);
+        let flipped_array = array.flip_axis([0]);
         assert_eq!(flipped_array.get_data(), &[4.0, 3.0, 2.0, 1.0]);
     }
 
     #[test]
     fn test_flip_array_axis1() {
         let array = NumArrayF32::new_with_shape(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
-        let flipped_array = array.flip_axes([1]);
+        let flipped_array = array.flip_axis([1]);
         assert_eq!(flipped_array.get_data(), &[3.0, 2.0, 1.0, 6.0, 5.0, 4.0]);
     }
 
@@ -1564,7 +1564,7 @@ mod tests {
             ],
             vec![2, 3, 2],
         );
-        let flipped_array = array.flip_axes([2]);
+        let flipped_array = array.flip_axis([2]);
         assert_eq!(
             flipped_array.get_data(),
             &[2., 1., 4., 3., 6., 5., 8., 7., 10., 9., 12., 11.]
@@ -1718,7 +1718,7 @@ mod tests {
     #[test]
     fn test_calculate_reduced_index_complex_3d_complex() {
         let shape = vec![3, 5, 4]; // This represents the shape of the data in 3D (3 blocks, 5 rows per block, 4 columns per row)
-        let reduction_shape = vec![1, 5, 1]; // This signifies reduction along the first and third axes
+        let reduction_shape = vec![1, 5, 1]; // This signifies reduction along the first and third axis
         let num_array = NumArrayF32 {
             data: vec![],
             shape,
@@ -1726,7 +1726,7 @@ mod tests {
             _ops: PhantomData,
         }; // Strides are not used in this test
 
-        // This tests a 3D array's reduction along non-adjacent axes.
+        // This tests a 3D array's reduction along non-adjacent axis.
         // Indices should map based on the remaining middle dimension.
         // The reduced index should vary only by changes in the middle dimension (rows), as the other two are collapsed.
         // We will test a few critical points across the dataset:
@@ -1753,49 +1753,49 @@ mod tests {
     }
 
     #[test]
-    fn test_mean_axes_1d() {
+    fn test_mean_axis_1d() {
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let array = NumArrayF32::new_with_shape(data, vec![4]);
-        let mean_array = array.mean_axes(Some(&[0]));
+        let mean_array = array.mean_axis(Some(&[0]));
         assert_eq!(mean_array.get_data(), &vec![2.5]);
     }
 
     #[test]
-    fn test_mean_axes_2d() {
+    fn test_mean_axis_2d() {
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let array = NumArrayF32::new_with_shape(data, vec![2, 3]);
-        let mean_array = array.mean_axes(Some(&[1]));
+        let mean_array = array.mean_axis(Some(&[1]));
 
         assert_eq!(mean_array.shape(), &[2]);
         assert_eq!(mean_array.get_data(), &vec![2.0, 5.0]); // Mean along the second axis (columns)
     }
 
     #[test]
-    fn test_mean_axes_2d_column() {
+    fn test_mean_axis_2d_column() {
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let array = NumArrayF32::new_with_shape(data, vec![2, 3]);
         // Compute mean across columns (axis 1)
-        let mean_array = array.mean_axes(Some(&[1]));
+        let mean_array = array.mean_axis(Some(&[1]));
         assert_eq!(mean_array.get_data(), &vec![2.0, 5.0]); // Mean along the second axis (columns)
     }
 
     #[test]
-    fn test_mean_axes_3d() {
+    fn test_mean_axis_3d() {
         let data = vec![
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
         ];
         let array = NumArrayF32::new_with_shape(data, vec![2, 2, 3]);
-        // Compute mean across the last two axes (1 and 2)
-        let mean_array = array.mean_axes(Some(&[1, 2]));
+        // Compute mean across the last two axis (1 and 2)
+        let mean_array = array.mean_axis(Some(&[1, 2]));
         assert_eq!(mean_array.get_data(), &vec![3.5, 9.5]);
     }
 
     #[test]
-    fn test_mean_axes_invalid_axis() {
+    fn test_mean_axis_invalid_axis() {
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let array = NumArrayF32::new_with_shape(data, vec![4]);
         // Attempt to compute mean across an invalid axis
-        let result = std::panic::catch_unwind(|| array.mean_axes(Some(&[1])));
+        let result = std::panic::catch_unwind(|| array.mean_axis(Some(&[1])));
         assert!(result.is_err(), "Should panic due to invalid axis");
     }
 
@@ -1929,36 +1929,36 @@ mod tests {
     }
 
     #[test]
-    fn test_min_axes_1d() {
+    fn test_min_axis_1d() {
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let array = NumArrayF32::new_with_shape(data, vec![4]);
-        let min_array = array.min_axes(Some(&[0]));
+        let min_array = array.min_axis(Some(&[0]));
         assert_eq!(min_array.get_data(), &vec![1.0]);
     }
 
     #[test]
-    fn test_min_axes_2d() {
+    fn test_min_axis_2d() {
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let array = NumArrayF32::new_with_shape(data, vec![2, 3]);
-        let min_array = array.min_axes(Some(&[1]));
+        let min_array = array.min_axis(Some(&[1]));
         assert_eq!(min_array.get_data(), &vec![1.0, 4.0]);
     }
 
     #[test]
-    fn test_min_axes_3d() {
+    fn test_min_axis_3d() {
         let data = vec![
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
         ];
         let array = NumArrayF32::new_with_shape(data, vec![2, 2, 3]);
-        let min_array = array.min_axes(Some(&[1, 2]));
+        let min_array = array.min_axis(Some(&[1, 2]));
         assert_eq!(min_array.get_data(), &vec![1.0, 7.0]);
     }
 
     #[test]
-    fn test_min_axes_invalid_axis() {
+    fn test_min_axis_invalid_axis() {
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let array = NumArrayF32::new_with_shape(data, vec![4]);
-        let result = std::panic::catch_unwind(|| array.min_axes(Some(&[1])));
+        let result = std::panic::catch_unwind(|| array.min_axis(Some(&[1])));
         assert!(result.is_err(), "Should panic due to invalid axis");
     }
 
@@ -1971,12 +1971,12 @@ mod tests {
     #[test]
     fn test_squeeze() {
         let array = NumArrayF32::new_with_shape(vec![1.0, 2.0], vec![1, 2, 1]);
-        let squeezed = array.squeeze(None); // removes all axes of length 1
+        let squeezed = array.squeeze(None); // removes all axis of length 1
         assert_eq!(squeezed.shape(), &[2]);
     }
 
     #[test]
-    fn test_squeeze_no_axes() {
+    fn test_squeeze_no_axis() {
         let array = NumArrayF32::new_with_shape(vec![1.0, 2.0], vec![1, 2, 1]);
         let squeezed = array.squeeze(None);
         assert_eq!(squeezed.shape(), &[2]);
@@ -1984,7 +1984,7 @@ mod tests {
     }
 
     #[test]
-    fn test_squeeze_specific_axes() {
+    fn test_squeeze_specific_axis() {
         let array = NumArrayF32::new_with_shape(vec![1.0, 2.0], vec![1, 2, 1]);
         let squeezed = array.squeeze(Some(&[0])); // Only squeeze first axis
         assert_eq!(squeezed.shape(), &[2, 1]);
@@ -1992,57 +1992,57 @@ mod tests {
     }
 
     #[test]
-    fn test_squeeze_multiple_axes() {
+    fn test_squeeze_multiple_axis() {
         let array = NumArrayF32::new_with_shape(vec![1.0, 2.0], vec![1, 2, 1, 1]);
-        let squeezed = array.squeeze(Some(&[0, 2])); // Squeeze first and third axes
+        let squeezed = array.squeeze(Some(&[0, 2])); // Squeeze first and third axis
         assert_eq!(squeezed.shape(), &[2, 1]);
         assert_eq!(squeezed.get_data(), &[1.0, 2.0]);
     }
 
     #[test]
-    fn test_max_axes_1d() {
+    fn test_max_axis_1d() {
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let array = NumArrayF32::new_with_shape(data, vec![4]);
-        let max_array = array.max_axes(Some(&[0]));
+        let max_array = array.max_axis(Some(&[0]));
         assert_eq!(max_array.get_data(), &vec![4.0]);
     }
 
     #[test]
-    fn test_max_axes_2d() {
+    fn test_max_axis_2d() {
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let array = NumArrayF32::new_with_shape(data, vec![2, 3]);
-        let max_array = array.max_axes(Some(&[1]));
+        let max_array = array.max_axis(Some(&[1]));
 
         assert_eq!(max_array.shape(), &[2]);
         assert_eq!(max_array.get_data(), &vec![3.0, 6.0]); // Max along the second axis (columns)
     }
 
     #[test]
-    fn test_max_axes_2d_column() {
+    fn test_max_axis_2d_column() {
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let array = NumArrayF32::new_with_shape(data, vec![2, 3]);
         // Compute max across columns (axis 1)
-        let max_array = array.max_axes(Some(&[1]));
+        let max_array = array.max_axis(Some(&[1]));
         assert_eq!(max_array.get_data(), &vec![3.0, 6.0]); // Max along the second axis (columns)
     }
 
     #[test]
-    fn test_max_axes_3d() {
+    fn test_max_axis_3d() {
         let data = vec![
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
         ];
         let array = NumArrayF32::new_with_shape(data, vec![2, 2, 3]);
-        // Compute max across the last two axes (1 and 2)
-        let max_array = array.max_axes(Some(&[1, 2]));
+        // Compute max across the last two axis (1 and 2)
+        let max_array = array.max_axis(Some(&[1, 2]));
         assert_eq!(max_array.get_data(), &vec![6.0, 12.0]);
     }
 
     #[test]
-    fn test_max_axes_invalid_axis() {
+    fn test_max_axis_invalid_axis() {
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let array = NumArrayF32::new_with_shape(data, vec![4]);
         // Attempt to compute max across an invalid axis
-        let result = std::panic::catch_unwind(|| array.max_axes(Some(&[1])));
+        let result = std::panic::catch_unwind(|| array.max_axis(Some(&[1])));
         assert!(result.is_err(), "Should panic due to invalid axis");
     }
 }


### PR DESCRIPTION
## Changes

- Rename all occurrences of `axes` with `axis` to match numpy naming.