### PR TITLE
Add python 3.13 support

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-13]
-        python-version: [38, 39, 310, 311, 312]
+        python-version: [38, 39, 310, 311, 312, 313]
     steps:
       - uses: actions/checkout@v4
 
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [38, 39, 310, 311, 312]
+        python-version: [38, 39, 310, 311, 312, 313]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test_python_bindings.yml
+++ b/.github/workflows/test_python_bindings.yml
@@ -2,9 +2,9 @@ name: Test Python Bindings
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -15,16 +15,18 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - version: '3.8'
-            tag: '38'
-          - version: '3.9'
-            tag: '39'
-          - version: '3.10'
-            tag: '310'
-          - version: '3.11'
-            tag: '311'
-          - version: '3.12'
-            tag: '312'
+          - version: "3.8"
+            tag: "38"
+          - version: "3.9"
+            tag: "39"
+          - version: "3.10"
+            tag: "310"
+          - version: "3.11"
+            tag: "311"
+          - version: "3.12"
+            tag: "312"
+          - version: "3.13"
+            tag: "313"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test_python_bindings.yml
+++ b/.github/workflows/test_python_bindings.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: ${{ matrix.python.version }}
 
       - name: Build Wheel
-        uses: pypa/cibuildwheel@v2.18.0
+        uses: pypa/cibuildwheel@v2.21.2
         with:
           output-dir: wheelhouse
           package-dir: ./bindings/python

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ RustyNum is a high-performance numerical computation library written in Rust, cr
 
 ## Installation
 
-Supported Python versions: `3.8`, `3.9`, `3.10`, `3.11`, `3.12`
+Supported Python versions: `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`
 
 Supported operating systems: `Windows x86`, `Linux x86`, `MacOS x86 & ARM`
 

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -11,3 +11,8 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.19.2", features = ["extension-module"] }
 rustynum-rs = { path = "../../rustynum-rs" }
+
+[profile.release]
+lto = true
+strip = true
+panic = "abort"

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -28,6 +28,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Rust",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ RustyNum is built to demonstrate the potential of **Rust's SIMD capabilities** w
 
 ### Seamless Python Integration
 - Python bindings offer a familiar interface for NumPy users.
-- Compatible with popular Python versions (3.8 - 3.12).
+- Compatible with popular Python versions (3.8 - 3.13).
 
 ### Lightweight and Portable
 - No external Rust crates used—keeping the codebase simple and transparent.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ Get started with RustyNum by following this installation guide. Whether you're u
 ## ✅ Supported Platforms and Versions
 
 ### Supported Python Versions
-- Python 3.8, 3.9, 3.10, 3.11, 3.12
+- Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13
 
 ### Supported Operating Systems
 - **Windows**: x86

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ Get started with RustyNum by following this installation guide. Whether you're u
 
 ### Supported Operating Systems
 - **Windows**: x86
-- **Linux**: x86
+- **Linux**: x86 & ARM
 - **MacOS**: x86 & ARM (Apple Silicon support)
 
 ---


### PR DESCRIPTION
## Changes

- Add Python 3.13 to build and tests
- Optimise build size using link time optimisation and reduction of error handling
- Update documentation