### PR TITLE
Implementing Median

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 **.pyc
 **rustynum.egg-info
 **__pycache__
+
+# Ignore compiled shared object files
+**/*.so

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 ![RustyNum Banner](docs/assets/rustynum-banner.png?raw=true "RustyNum")
 
-
 [![PyPI python](https://img.shields.io/pypi/pyversions/rustynum)](https://pypi.org/project/rustynum)
 ![PyPI Version](https://badge.fury.io/py/rustynum.svg)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Test Python Bindings](https://github.com/IgorSusmelj/rustynum/actions/workflows/test_python_bindings.yml/badge.svg)
 [![Documentation](https://img.shields.io/badge/docs-rustynum.com-blue)](https://rustynum.com)
-
 
 ---
 
@@ -102,6 +100,7 @@ RustyNum offers a variety of numerical operations and data types, with more feat
 | Arange           | `np.arange(start, stop, step)`  | `rnp.arange(start, stop, step)`  |
 | Linspace         | `np.linspace(start, stop, num)` | `rnp.linspace(start, stop, num)` |
 | Mean             | `np.mean(a)`                    | `rnp.mean(a)`                    |
+| Median           | `np.median(a)`                  | `rnp.median(a)`                  |
 | Min              | `np.min(a)`                     | `rnp.min(a)`                     |
 | Max              | `np.max(a)`                     | `rnp.max(a)`                     |
 | Exp              | `np.exp(a)`                     | `rnp.exp(a)`                     |
@@ -171,6 +170,15 @@ average = a.mean()
 average_axis0 = a.mean(axis=0)
 ```
 
+`median(axis: Union[None, int, Sequence[int]] = None) -> Union[NumArray, float]`
+
+Computes the median along specified axis.
+
+```Python
+median = a.median()
+median_axis0 = a.median(axis=0)
+```
+
 `min(axis: Union[None, int, Sequence[int]] = None) -> Union[NumArray, float]`
 
 Returns the minimum value in the array.
@@ -206,7 +214,7 @@ Planned Features:
 
 - N-dimensional arrays
   - Useful for filters, image processing, and machine learning
-- Additional operations: median, argmin, argmax, sort, std, var, zeros, cumsum, interp
+- Additional operations: argmin, argmax, sort, std, var, zeros, cumsum, interp
 - Integer support
 - Extended shaping and reshaping capabilities
 - C++ and WASM bindings
@@ -235,6 +243,7 @@ RustyNum leverages Rust's `portable_simd` feature to achieve significant perform
 | Operation                   | RustyNum (us)  | Numpy (us)     | Speedup Factor |
 | --------------------------- | -------------- | -------------- | -------------- |
 | Mean (1000 elements)        | 8.8993         | 22.6300        | 2.54x          |
+| Median (1000 elements)      | 23.6040        | 39.8451        | 1.68x          |
 | Min (1000 elements)         | 10.1423        | 28.9693        | 2.86x          |
 | Sigmoid (1000 elems)        | 10.6899        | 23.2486        | 2.17x          |
 | Dot Product (1000 elems)    | 17.0640        | 38.2958        | 2.24x          |
@@ -248,6 +257,7 @@ RustyNum leverages Rust's `portable_simd` feature to achieve significant perform
 | Operation                   | RustyNum (us)  | Numpy (us)     | Speedup Factor |
 | --------------------------- | -------------- | -------------- | -------------- |
 | Mean (1000 elements)        | 9.1026         | 24.0636        | 2.64x          |
+| Median (1000 elements)      | 24.9010        | 38.4760        | 1.54x          |
 | Min (1000 elements)         | 18.2651        | 24.8170        | 1.36x          |
 | Dot Product (1000 elems)    | 16.6583        | 38.8000        | 2.33x          |
 | Matrix-Vector (1000x1000)   | 9,941.3305     | 23,788.9570    | 2.39x          |
@@ -257,7 +267,7 @@ RustyNum leverages Rust's `portable_simd` feature to achieve significant perform
 
 #### Observations
 
-- RustyNum significantly outperforms Numpy in basic operations such as mean, min, and dot product, with speedup factors over 2x.
+- RustyNum significantly outperforms Numpy in basic operations such as mean, median, min, and dot product, with speedup factors up to and over 2x.
 - For larger operations, especially matrix-vector and matrix-matrix multiplications, Numpy currently performs better, which highlights areas for potential optimization in RustyNum.
 
 These results demonstrate RustyNum's potential for high-performance numerical computations, particularly in operations where SIMD instructions can be fully leveraged.
@@ -272,6 +282,7 @@ In addition to the Python bindings, RustyNum’s core library is implemented in 
 | ------------------------------------------- | --------- | --------- | --------- |
 | Addition (10k elements)                     | 760.53 ns | 695.73 ns | 664.29 ns |
 | Vector mean (10k elements)                  | 683.83 ns | 14.602 µs | 1.2370 µs |
+| Vector median (10k elements)                | 7.4175 µs | 6.8863 µs | 6.9970 µs |
 | Vector Dot Product (10k elements)           | 758.65 ns | 1.1843 µs | 1.1942 µs |
 | Matrix-Vector Multiplication (1k elements)  | 77.851 us | 403.39 µs | 115.75 µs |
 | Matrix-Matrix Multiplication (500 elements) | 2.5526 ms | 2.9038 ms | 2.7847 ms |
@@ -310,7 +321,7 @@ Run using
 
 ```
 
-cargo criterion
+cargo bench -- <benchmark_name>
 
 ```
 

--- a/bindings/python/benchmarks/test_performance_addition.py
+++ b/bindings/python/benchmarks/test_performance_addition.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import rustynum as rnp
 
 

--- a/bindings/python/benchmarks/test_performance_basics.py
+++ b/bindings/python/benchmarks/test_performance_basics.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import rustynum as rnp
 
 

--- a/bindings/python/benchmarks/test_performance_dot.py
+++ b/bindings/python/benchmarks/test_performance_dot.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import rustynum as rnp
 
 

--- a/bindings/python/benchmarks/test_performance_gemm.py
+++ b/bindings/python/benchmarks/test_performance_gemm.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import rustynum as rnp
 
 

--- a/bindings/python/benchmarks/test_performance_gemv.py
+++ b/bindings/python/benchmarks/test_performance_gemv.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import rustynum as rnp
 
 

--- a/bindings/python/benchmarks/test_performance_mean.py
+++ b/bindings/python/benchmarks/test_performance_mean.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import rustynum as rnp
 
 

--- a/bindings/python/benchmarks/test_performance_mean_nd.py
+++ b/bindings/python/benchmarks/test_performance_mean_nd.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import rustynum as rnp
 
 

--- a/bindings/python/benchmarks/test_performance_median.py
+++ b/bindings/python/benchmarks/test_performance_median.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+import rustynum as rnp
+
+
+# Helper function to generate random vectors
+def setup_vector(dtype, size=1000):
+    a = np.random.rand(size).astype(dtype)
+    return a.tolist()
+
+
+# Function to perform median using rustynum
+def median_rustynum(a, dtype):
+    a_rnp = rnp.NumArray(a, dtype=dtype)
+    return a_rnp.median()
+
+
+# Function to perform median using numpy
+def median_numpy(a, dtype):
+    a_np = np.array(a, dtype=dtype)
+    return np.median(a_np)
+
+
+# Parametrized test function for different libraries, data types, and sizes
+@pytest.mark.parametrize(
+    "func,dtype,size",
+    [
+        (median_rustynum, "float32", 1000),
+        (median_rustynum, "float64", 1000),
+        (median_numpy, "float32", 1000),
+        (median_numpy, "float64", 1000),
+        (median_rustynum, "float32", 10000),
+        (median_rustynum, "float64", 10000),
+        (median_numpy, "float32", 10000),
+        (median_numpy, "float64", 10000),
+    ],
+)
+def test_median(benchmark, func, dtype, size):
+    a = setup_vector(dtype, size)
+    group_name = f"{dtype}"
+
+    benchmark.group = group_name
+    benchmark.extra_info["dtype"] = dtype
+    benchmark.extra_info["size"] = size
+    benchmark(func, a, dtype)

--- a/bindings/python/benchmarks/test_performance_median.py
+++ b/bindings/python/benchmarks/test_performance_median.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import rustynum as rnp
 
 

--- a/bindings/python/benchmarks/test_performance_median_nd.py
+++ b/bindings/python/benchmarks/test_performance_median_nd.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import rustynum as rnp
 
 

--- a/bindings/python/benchmarks/test_performance_median_nd.py
+++ b/bindings/python/benchmarks/test_performance_median_nd.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+import rustynum as rnp
+
+
+# Helper function to generate random vectors
+def setup_vector(dtype, size=1000):
+    a = np.random.rand(size).astype(dtype)
+    return a.tolist()
+
+
+# Function to perform median using rustynum
+def median_rustynum(a, dtype):
+    a_rnp = rnp.NumArray(a, dtype=dtype)
+    a_rnp = a_rnp.reshape([2, 4, len(a) // 8])
+    return a_rnp.median()
+
+
+# Function to perform median using numpy
+def median_numpy(a, dtype):
+    a_np = np.array(a, dtype=dtype)
+    a_np = a_np.reshape([2, 4, len(a) // 8])
+    return np.median(a_np)
+
+
+# Parametrized test function for different libraries, data types, and sizes
+@pytest.mark.parametrize(
+    "func,dtype,size",
+    [
+        (median_rustynum, "float32", 1000),
+        (median_rustynum, "float64", 1000),
+        (median_numpy, "float32", 1000),
+        (median_numpy, "float64", 1000),
+        (median_rustynum, "float32", 10000),
+        (median_rustynum, "float64", 10000),
+        (median_numpy, "float32", 10000),
+        (median_numpy, "float64", 10000),
+    ],
+)
+def test_median_n_dimensional(benchmark, func, dtype, size):
+    a = setup_vector(dtype, size)
+    group_name = f"{dtype}"
+
+    benchmark.group = group_name
+    benchmark.extra_info["dtype"] = dtype
+    benchmark.extra_info["size"] = size
+    benchmark(func, a, dtype)

--- a/bindings/python/benchmarks/test_performance_min.py
+++ b/bindings/python/benchmarks/test_performance_min.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import rustynum as rnp
 
 

--- a/bindings/python/benchmarks/test_performance_norm.py
+++ b/bindings/python/benchmarks/test_performance_norm.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import rustynum as rnp
 
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -5,3 +5,7 @@ requires = [
     "setuptools_rust"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.poetry]
+name = "rustynum"
+version="0.1.6"

--- a/bindings/python/rustynum/__init__.py
+++ b/bindings/python/rustynum/__init__.py
@@ -347,6 +347,48 @@ class NumArray:
         )
         return NumArray(result, dtype=self.dtype)
 
+    def median(
+        self, axis: Union[None, int, Sequence[int]] = None
+    ) -> Union["NumArray", float]:
+        """
+        Computes the median of the NumArray along specified axis.
+
+        Parameters:
+            axis: Optional; Axis or axis along which to compute the median. If None, the median
+                  of all elements is computed as a scalar.
+
+        Returns:
+            A new NumArray with the median values along the specified axis, or a scalar if no axis are given.
+        """
+        axis = [axis] if isinstance(axis, int) else axis
+        result = (
+            _rustynum.median_f32(self.inner, axis)
+            if self.dtype == "float32"
+            else _rustynum.median_f64(self.inner, axis)
+        )
+        return NumArray(result, dtype=self.dtype)
+
+    def median(
+        self, axis: Union[None, int, Sequence[int]] = None
+    ) -> Union["NumArray", float]:
+        """
+        Computes the median of the NumArray along specified axis.
+
+        Parameters:
+            axis: Optional; Axis or axis along which to compute the median. If None, the median
+                  of all elements is computed as a scalar.
+
+        Returns:
+            A new NumArray with the median values along the specified axis, or a scalar if no axis are given.
+        """
+        axis = [axis] if isinstance(axis, int) else axis
+        result = (
+            _rustynum.median_f32(self.inner, axis)
+            if self.dtype == "float32"
+            else _rustynum.median_f64(self.inner, axis)
+        )
+        return NumArray(result, dtype=self.dtype)
+
     def min(
         self, axis: Union[None, int, Sequence[int]] = None
     ) -> Union["NumArray", float]:
@@ -724,6 +766,17 @@ def mean(a: "NumArray") -> float:
     else:
         raise TypeError(
             "Unsupported operand type for mean: '{}'".format(type(a).__name__)
+        )
+
+
+def median(a: "NumArray") -> float:
+    if isinstance(a, NumArray):
+        return a.median()
+    elif isinstance(a, (int, float)):
+        return NumArray([a], dtype="float32").median()
+    else:
+        raise TypeError(
+            "Unsupported operand type for median: '{}'".format(type(a).__name__)
         )
 
 

--- a/bindings/python/tests/test_array_ops.py
+++ b/bindings/python/tests/test_array_ops.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import rustynum as rnp
 
 

--- a/bindings/python/tests/test_basics.py
+++ b/bindings/python/tests/test_basics.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import rustynum as rnp
 
 

--- a/bindings/python/tests/test_complex_flows.py
+++ b/bindings/python/tests/test_complex_flows.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import rustynum as rnp
 
 

--- a/bindings/python/tests/test_dot_product.py
+++ b/bindings/python/tests/test_dot_product.py
@@ -1,6 +1,7 @@
 # bindings/python/tests/test_dot_product.py
 
 import numpy as np
+
 import rustynum as rnp
 
 

--- a/bindings/python/tests/test_matrix_multiplication.py
+++ b/bindings/python/tests/test_matrix_multiplication.py
@@ -1,6 +1,7 @@
 import numpy as np
-import rustynum as rnp
 import pytest
+
+import rustynum as rnp
 
 
 def test_matmul_f32_basic():

--- a/bindings/python/tests/test_mean.py
+++ b/bindings/python/tests/test_mean.py
@@ -1,6 +1,7 @@
 # bindings/python/tests/test_dot_product.py
 
 import numpy as np
+
 import rustynum as rnp
 
 

--- a/bindings/python/tests/test_median.py
+++ b/bindings/python/tests/test_median.py
@@ -1,6 +1,7 @@
 # bindings/python/tests/test_dot_product.py
 
 import numpy as np
+
 import rustynum as rnp
 
 

--- a/bindings/python/tests/test_median.py
+++ b/bindings/python/tests/test_median.py
@@ -1,0 +1,47 @@
+# bindings/python/tests/test_dot_product.py
+
+import numpy as np
+import rustynum as rnp
+
+
+def test_median_f32_small():
+    a = [1.0, 2.0, 3.0, 4.0]
+    a_py = rnp.NumArray(a, dtype="float32")
+    result_rusty_1 = a_py.median().item()
+    result_rusty_2 = rnp.median(a_py).item()
+    result_numpy = np.median(a).item()
+
+    assert np.isclose(
+        result_rusty_1, result_numpy, atol=1e-6
+    ), "Mean for f32 failed with error"
+
+    assert np.isclose(
+        result_rusty_2, result_numpy, atol=1e-6
+    ), "Mean for f32 failed with error"
+
+
+def test_median_f32_axis():
+    # Create a 2D array and wrap it in NumArray
+    a = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], dtype=np.float32)
+    a_py = rnp.NumArray(a.tolist(), dtype="float32")
+
+    a = a.reshape((2, 3))
+    a_py = a_py.reshape([2, 3])
+
+    # Compute median along different axis
+    result_rusty_axis0 = a_py.median(axis=0)
+    result_rusty_axis1 = a_py.median(axis=1)
+    result_numpy_axis0 = np.median(a, axis=0)
+    result_numpy_axis1 = np.median(a, axis=1)
+
+    print(result_rusty_axis0.tolist(), result_numpy_axis0)
+    print(result_rusty_axis1.tolist(), result_numpy_axis1)
+
+    # Check if the means are close
+    assert np.allclose(
+        result_rusty_axis0.tolist(), result_numpy_axis0, atol=1e-6
+    ), "Mean along axis 0 for f32 failed"
+
+    assert np.allclose(
+        result_rusty_axis1.tolist(), result_numpy_axis1, atol=1e-6
+    ), "Mean along axis 1 for f32 failed"

--- a/bindings/python/tests/test_min_max.py
+++ b/bindings/python/tests/test_min_max.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+
 import rustynum as rnp
 
 

--- a/bindings/python/tests/test_norm.py
+++ b/bindings/python/tests/test_norm.py
@@ -1,6 +1,7 @@
 import math
 
 import numpy as np
+
 import rustynum as rnp
 
 

--- a/rustynum-rs/src/num_array/mod.rs
+++ b/rustynum-rs/src/num_array/mod.rs
@@ -1,3 +1,3 @@
+pub mod linalg;
 pub mod num_array;
 pub mod operations;
-pub mod linalg;

--- a/rustynum-rs/src/num_array/num_array.rs
+++ b/rustynum-rs/src/num_array/num_array.rs
@@ -553,6 +553,125 @@ where
             None => self.mean(),
         }
     }
+
+    /// Sorts the array in ascending order.
+    /// The original array is not modified.
+    /// # Returns
+    /// A new `NumArray` instance containing the sorted values.
+    /// # Example
+    /// ```
+    /// use rustynum_rs::NumArrayF32;
+    /// let data = vec![3.0, 1.0, 4.0, 2.0];
+    /// let array = NumArrayF32::new(data);
+    /// let sorted_array = array.sort();
+    /// println!("Sorted array: {:?}", sorted_array.get_data());
+    /// ```
+
+    pub fn sort(&self) -> NumArray<T, Ops> {
+        let mut sorted_data = self.data.clone();
+        sorted_data.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        NumArray::new(sorted_data)
+    }
+
+    fn calculate_median(values: &[T]) -> T {
+        let len = values.len();
+        if len % 2 == 0 {
+            (values[len / 2 - 1] + values[len / 2]) / T::from_u32(2)
+        } else {
+            values[len / 2]
+        }
+    }
+
+    /// Computes the median of the array.
+    /// The original array is not modified.
+    ///
+    /// # Returns
+    /// A new `NumArray` instance containing the median value.
+    ///
+    /// # Examples
+    /// ```
+    /// use rustynum_rs::NumArrayF32;
+    /// let data = vec![3.0, 1.0, 4.0, 2.0];
+    /// let array = NumArrayF32::new(data);
+    /// let median_array = array.median();
+    /// println!("Median array: {:?}", median_array.get_data());
+    /// ```
+    ///
+
+    pub fn median(&self) -> NumArray<T, Ops> {
+        let sorted_data = self.sort();
+        let median = Self::calculate_median(sorted_data.get_data());
+
+        NumArray::new(vec![median])
+    }
+
+    /// Computes the median along the specified axis.
+    /// The original array is not modified.
+    ///
+    /// # Parameters
+    /// * `axis` - An optional reference to a vector of axis to compute the median along.
+    ///
+    /// # Returns
+    /// A new `NumArray` instance containing the median values along the specified axis.
+    ///
+    /// # Panics
+    /// Panics if any of the specified axis is out of bounds.
+    ///
+    /// # Examples
+    /// ```
+    /// use rustynum_rs::NumArrayF32;
+    /// let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    /// let array = NumArrayF32::new_with_shape(data, vec![2, 3]);
+    /// let median_array = array.median_axis(Some(&[1]));
+    /// println!("Median array: {:?}", median_array.get_data());
+    /// ```
+
+    pub fn median_axis(&self, axis: Option<&[usize]>) -> NumArray<T, Ops> {
+        // TODO_A: Improve efficiency. More in place, less copy, check SIMD
+        match axis {
+            Some(axis) => {
+                let mut reduced_shape = self.shape.clone();
+                let mut total_elements_to_reduce = 1;
+                for &axis in axis {
+                    assert!(axis < self.shape.len(), "Axis {} out of bounds.", axis);
+                    reduced_shape[axis] = 1;
+                    total_elements_to_reduce *= self.shape[axis];
+                }
+
+                let reduced_size: usize = reduced_shape.iter().product();
+                let mut reduced_data = vec![T::from_u32(0); reduced_size];
+
+                let mut accumulator = vec![T::from_u32(0); total_elements_to_reduce * reduced_size];
+
+                let mut accumulator_ptrs: Vec<&mut [T]> =
+                    accumulator.chunks_mut(total_elements_to_reduce).collect();
+                let mut counts = vec![0; accumulator_ptrs.len()];
+
+                for (i, &val) in self.data.iter().enumerate() {
+                    let reduced_idx = self.calculate_reduced_index(i, &reduced_shape);
+                    accumulator_ptrs[reduced_idx][counts[reduced_idx]] = val;
+                    counts[reduced_idx] += 1;
+                }
+
+                for (i, ptr) in accumulator_ptrs.iter_mut().enumerate() {
+                    ptr.sort_by(|a, b| a.partial_cmp(b).unwrap());
+                    reduced_data[i] = Self::calculate_median(ptr);
+                }
+
+                reduced_shape = reduced_shape
+                    .into_iter()
+                    .filter(|&x| x != 1)
+                    .collect::<Vec<_>>();
+
+                if reduced_shape.is_empty() {
+                    return NumArray::new(reduced_data);
+                } else {
+                    return NumArray::new_with_shape(reduced_data, reduced_shape);
+                }
+            }
+            None => self.median(),
+        }
+    }
 }
 
 impl<T, Ops> NumArray<T, Ops>
@@ -1899,6 +2018,92 @@ mod tests {
         // Attempt to compute mean across an invalid axis
         let result = std::panic::catch_unwind(|| array.mean_axis(Some(&[1])));
         assert!(result.is_err(), "Should panic due to invalid axis");
+    }
+
+    #[test]
+    fn test_sort_f32() {
+        let a = NumArrayF32::from(vec![5.0, 2.0, 3.0, 1.0, 4.0]);
+        assert_eq!(a.sort().get_data(), &[1.0, 2.0, 3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn test_sort_f64() {
+        let a = NumArrayF64::from(vec![5.0, 2.0, 3.0, 1.0, 4.0]);
+        assert_eq!(a.sort().get_data(), &[1.0, 2.0, 3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn test_median_f32_one_elem() {
+        let a = NumArrayF32::from(vec![1.0]);
+        assert_eq!(a.median().item(), 1.0);
+    }
+
+    #[test]
+    fn test_median_f32_even() {
+        let a = NumArrayF32::from(vec![2.0, 1.0, 4.0, 3.0, 6.0, 5.0]);
+        assert_eq!(a.median().item(), 3.5);
+    }
+
+    #[test]
+    fn test_median_f32_uneven() {
+        let a = NumArrayF32::from(vec![2.0, 1.0, 2.0, 4.0, 5.0, 6.0, 7.0]);
+        assert_eq!(a.median().item(), 4.0);
+    }
+
+    #[test]
+    fn test_median_f64_uneven() {
+        let a = NumArrayF64::from(vec![1.0, 2.0, 2.0, 4.0, 5.0, 6.0, 7.0]);
+        assert_eq!(a.median().item(), 4.0);
+    }
+
+    #[test]
+    fn test_median_axis_1d_even() {
+        let data = vec![2.0, 1.0, 4.0, 3.0, 6.0, 5.0];
+        let array = NumArrayF32::new_with_shape(data, vec![6]);
+        let max_array = array.median_axis(Some(&[0]));
+        assert_eq!(max_array.get_data(), &vec![3.5]);
+    }
+
+    #[test]
+    fn test_median_axis_1d_uneven() {
+        let data = vec![2.0, 2.0, 4.0, 3.0, 6.0, 5.0, 7.0];
+        let array = NumArrayF32::new_with_shape(data, vec![7]);
+        let max_array = array.median_axis(Some(&[0]));
+        assert_eq!(max_array.get_data(), &vec![4.0]);
+    }
+
+    #[test]
+    fn test_median_axis_2d_even() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let array = NumArrayF32::new_with_shape(data, vec![2, 3]);
+        let max_array = array.median_axis(Some(&[0]));
+        assert_eq!(max_array.get_data(), &vec![2.5, 3.5, 4.5]);
+    }
+
+    #[test]
+    fn test_median_axis_2d_uneven() {
+        let data = vec![2.0, 1.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+        let array = NumArrayF32::new_with_shape(data, vec![3, 3]);
+        let max_array = array.median_axis(Some(&[1]));
+        assert_eq!(max_array.get_data(), &vec![2.0, 5.0, 8.0]);
+    }
+
+    #[test]
+    fn test_median_axis_3d_even() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let array = NumArrayF32::new_with_shape(data, vec![2, 2, 2]);
+        let max_array = array.median_axis(Some(&[0, 1]));
+        assert_eq!(max_array.get_data(), &vec![4.0, 5.0]);
+    }
+
+    #[test]
+    fn test_median_axis_3d_uneven() {
+        let data = vec![
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+        ];
+        let array = NumArrayF32::new_with_shape(data, vec![3, 2, 2]);
+        let max_array = array.median_axis(Some(&[0]));
+        assert_eq!(max_array.get_data(), &vec![5.0, 6.0, 7.0, 8.0]);
     }
 
     #[test]

--- a/rustynum-rs/src/num_array/num_array.rs
+++ b/rustynum-rs/src/num_array/num_array.rs
@@ -627,7 +627,6 @@ where
     /// ```
 
     pub fn median_axis(&self, axis: Option<&[usize]>) -> NumArray<T, Ops> {
-        // TODO_A: Improve efficiency. More in place, less copy, check SIMD
         match axis {
             Some(axis) => {
                 let mut reduced_shape = self.shape.clone();


### PR DESCRIPTION
I implemented the median:

- Note that I did not take advantage of SIMD here. I guess it might make sense to look into sorting algorithms that work with SIMD. Maybe this one: [highway](https://github.com/google/highway) and [here](https://github.com/google/highway/tree/master/hwy/contrib/sort). Still the performance is quite ok, compared to numpy (see benchmarks below)

- I did some minor changes, like using `Isort` to sort all python imports and add poetry tool configs to `pyproject.toml`. The latter may be a bit annoying, as the package version is in `setup.py` as well. However, if dependencies are managed through a Poetry lock-file, then poetry should be "properly" integrated (IMHO). I ran into some issues when using `vim-test` test runners, as they explicitly check for a `poetry.lock` file and then expect a poetry config. Anyways, the changes are in individual commits and can easily be reverted.

- Note: I noticed, that the return shapes are a bit inconsistent. For for the median I chose this:
````
               if reduced_shape.is_empty() {
                    return NumArray::new(reduced_data);
                } else {
                    return NumArray::new_with_shape(reduced_data, reduced_shape);
                }
````
I think we still want to return a NumArray, even if it is a scalar, the `item()` function can then extract the scalar
Also: I think `new_with_shape` should panic, if the data vector does not fit with the provided shape. Currently, tests can pass even if a NumArray with data / shape mismatch is created.

Hope this is helpful. If not it was still fun 🎉 

![1](https://github.com/user-attachments/assets/f0b9b96f-283c-49ab-92bb-a0f325a412bc)
